### PR TITLE
Fixed building process for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "webinos_pzp": "webinos_pzp.js"
   },
   "scripts": {
-    "install": "./build_webinosJS.js",
+    "install": "node build_webinosJS.js",
     "test": "./tools/travis/auto-test.sh"
   }
 }


### PR DESCRIPTION
Windows can't execute js files as node modules. Added the node command infront of the build script.
