### PR TITLE
Fix policy manager loading

### DIFF
--- a/lib/pzp_otherManager.js
+++ b/lib/pzp_otherManager.js
@@ -161,11 +161,14 @@ var PzpOtherManager = function () {
     function initialize_PolicyManager() {
         try {
             if (require.resolve("webinos-policy")) {
-                var pm = require(PzpCommon.path.join(require.resolve("webinos-policy"), "../../lib/rpcInterception.js"));
+                var polPath = PzpCommon.path.join(
+                    require.resolve("webinos-policy"), "..", "rpcInterception.js");
+                var pm = require(polPath);
                 pm.setRPCHandler(rpcHandler);
             }
         } catch(err){
-            logger.log("Webinos Policy Manager is not present. It is unSecure to run PZP without policy");
+            logger.log("Webinos Policy Manager is not present. It is insecure to run webinos without policy enforcement.");
+            logger.log(err);
             return;
         }
     }


### PR DESCRIPTION
The policy manager was not loading due to it being invoked
with the wrong path.  This patch fixes that problem by
looking for the policy manager in node_modules.

See also: https://github.com/webinos/webinos-policy/pull/6

http://jira.webinos.org/browse/WP-968

Jira issue: WP-968
