### PR TITLE
Make the policy manager mandatory.

### DIFF
--- a/lib/pzp.js
+++ b/lib/pzp.js
@@ -4,11 +4,10 @@ var mandatoryModule = ["webinos-utilities",
     "webinos-jsonrpc2",
     "webinos-api-serviceDiscovery",
     "webinos-api-test",
+    "webinos-policy",
     "webinos-messaging"
 ];
-var optionalModule = ["webinos-synchronization",
-    "webinos-policy"
-];
+var optionalModule = ["webinos-synchronization"];
 mandatoryModule.forEach(function(name) {
     if (!require.resolve(name)) {
         throw new Error("Webinos PZP mandatory module "+ name + " is missing, these modules are compulsory for PZP to run. " +


### PR DESCRIPTION
Authorisation is a necessary part of webinos.  To not have it, is to
run without adequate security.  Having _a_ policy-manager module should
therefore be mandatory, not optional.

Jira issue: WP-981
