### PR TITLE
Fix service discovery not being found

### DIFF
--- a/wrt/webinos.js
+++ b/wrt/webinos.js
@@ -109,7 +109,5 @@
 
     webinos.rpcHandler = new RPCHandler (undefined, new Registry ());
     webinos.messageHandler = new MessageHandler (webinos.rpcHandler);
-    webinos.discovery = new ServiceDiscovery (webinos.rpcHandler);
-    webinos.ServiceDiscovery = webinos.discovery; // for backward compat
 
 } ());


### PR DESCRIPTION
As part of the others fixes for WP-848 this was missing. webinos.discovery
is now defined in the discovery wrt code itself.

Jira-issue: [WP-848](http://jira.webinos.org/browse/WP-848)
