### PR TITLE
pass path to node_modules to module loading funcs

### DIFF
--- a/lib/pzp_otherManager.js
+++ b/lib/pzp_otherManager.js
@@ -184,10 +184,11 @@ var PzpOtherManager = function () {
         }
     };
     this.loadModules = function() {
-        var newModules = PzpCommon.wUtil.webinosService.checkForWebinosModules();
+        var nodeModulesPath = PzpCommon.path.join(__dirname, "../node_modules");
+        var newModules = PzpCommon.wUtil.webinosService.checkForWebinosModules(nodeModulesPath);
         PzpObject.setServiceCache(newModules); // Add new Modules in serviceCache
         PzpCommon.wUtil.webinosService.loadServiceModules(PzpObject.getServiceCache(), registry, rpcHandler); // load specified modules
-        PzpCommon.wUtil.webinosService.createWebinosJS(); //Creates initial webinosJSPzp
+        PzpCommon.wUtil.webinosService.createWebinosJS(nodeModulesPath, PzpObject.getServiceCache()); // Creates initial webinosJSPzp
     };
     /**
      * Initializes Webinos Other Components that interact with the session manager


### PR DESCRIPTION
fixes loading api modules that are installed with npm link.

Jira-issue: [WP-1018](http://jira.webinos.org/browse/WP-1018)
