### PR TITLE
Fix enrolment in line with PZH user identity changes

### DIFF
--- a/lib/pzp_connectPzh.js
+++ b/lib/pzp_connectPzh.js
@@ -60,7 +60,7 @@ var PzpConnectHub = function () {
      */
     this.connectHub = function () {
         try {
-            logger.log("connection towards pzh "+ PzpObject.getPzhId() +" initiated");
+            logger.log("Initiating connection with PZH " + PzpObject.getPzhId() + " at address " + PzpObject.getServerAddress() + ", on port: " + PzpObject.getPorts().provider);
             var socket = PzpCommon.net.createConnection(PzpObject.getPorts().provider,  PzpObject.getServerAddress()); //Check if we are online..
             socket.setTimeout(10);
             socket.on('connect', function() {
@@ -100,7 +100,8 @@ var PzpConnectHub = function () {
                     PzpObject.emit("CONNECTION_FAILED", err);
                 });
             });
-            socket.on('error', function() { // Assuming this will happen as internet is not reachable
+            socket.on('error', function(err) { // Assuming this will happen as internet is not reachable
+               console.log(err);
                logger.log("currently your PZH is offline.");
                 retryConnecting();
             });

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -630,7 +630,7 @@ function Pzp(inputConfig) {
         config.cert.internal.pzh.cert    = payload.masterCert;
         config.cert.crl.value            = payload.masterCrl;
         config.metaData.pzhId            = from;
-        config.metaData.serverName       = from && from.split ("_")[0];
+        config.metaData.serverName       = from && from.split ("@")[1];
         // Same PZP name existed in PZ, PZH has assigned a new id to the PZP.
         if ((to.split("/") && to.split("/")[1])!== config.metaData.webinosName) {
             config.metaData.pzhAssignedId = to.split("/")[1];

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -227,6 +227,17 @@ function PzpWebSocketServer(){
         return undefined;
     }
 
+    function isSameOriginString(urlStringA, urlStringB) {
+        var url = require('url');
+        return isSameOrigin(url.parse(urlStringA), url.parse(urlStringB));
+    }
+
+    function isSameOrigin(urlA, urlB) {
+        return  urlA.protocol === urlB.protocol && 
+                urlA.port     === urlB.port &&
+                urlA.hostname === urlB.hostname;  
+    }
+
     function wsMessage (connection, origin, utf8Data) {
         //schema validation
         var key, msg = JSON.parse (utf8Data), invalidSchemaCheck = true;
@@ -272,10 +283,16 @@ function PzpWebSocketServer(){
                 case "webinosVersion":
                     getVersion(msg.from);
                     break;
-                case "authCodeByPzh":
-                    if (expectedPzhAddress === msg.payload.providerDetails) {
+                case "enrolRequestCSR":
+                    logger.log("Enrolment of the PZP requested from origin - " + origin );
+                    //TODO: Check that we're not already enrolled.
+                    if (isSameOriginString(expectedPzhAddress, origin)) {
                         connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
-                            "payload":{"status":"csrAuthCodeByPzp", "csr":PzpObject.getCertificateToBeSignedByPzh()}}));
+                            "payload":{"status":"csrFromPzp", "csr":PzpObject.getCertificateToBeSignedByPzh()}}));
+                    } else {
+                        logger.error("Enrolment failed: the website/app attempting to enrol the PZH was unexpected.");
+                        connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
+                            "payload":{"status":"enrolmentFailure"}}));
                     }
                     break;
                 case "pzpId_Update":
@@ -287,16 +304,25 @@ function PzpWebSocketServer(){
                         PzpObject.setupMessage_RPCHandler();
                         // set device name
                         connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
-                            "payload":{"status":"csrAuthCodeByPzp", "csr":PzpObject.getCertificateToBeSignedByPzh()}}));
+                            "payload":{"status":"csrFromPzp", "csr":PzpObject.getCertificateToBeSignedByPzh()}}));
                     }
                     break;
                 case "signedCertByPzh":
-                    if (expectedPzhAddress === (msg.from && msg.from.split("_") && msg.from.split("_")[0])) {
+                    logger.log("Received signed certificates from the PZH, this PZP can now connect.");
+                    // We need to check the origin, nothing else matters.
+                    if (isSameOriginString(expectedPzhAddress, origin)) {
                         PzpObject.registerDevice (msg.from, msg.to, msg.payload.message);
+                        connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
+                            "payload":{"status":"enrolmentSuccess"}}));
+                    } else {
+                        logger.error("Enrolment failed: the website/app attempting to enrol the PZH was unexpected.");
+                        connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
+                            "payload":{"status":"enrolmentFailure"}}));
                     }
                     break;
                 case "setPzhProviderAddress":
-                    expectedPzhAddress = msg.payload.message;
+                    //TODO: This really should check that the right origin is setting the PZH Provider address
+                    expectedPzhAddress = "https://" + msg.payload.message;
                     break;
                 case "pzpFindPeers":
                     PzpObject.sendPzpPeersToApp();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "webinos-pzp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Webinos device functionality is implemented in PZP",
   "main": "./lib/pzp_sessionHandling.js",
   "author": "Habib Virji  <habib.virji@samsung.com>",  


### PR DESCRIPTION
A number of changes at the PZH and PZH web server mean that
the PZP was not enrolling properly.  This has now been fixed.

In addition, the PZP will now report when enrolment was a
success or not (at least in some cases) and the new PZH and PZHWS
code should be a bit friendlier.

Depends on:
https://github.com/webinos/webinos-pzhWebServer/pull/6
https://github.com/webinos/webinos-pzh/pull/8

Warning: will break with pzh.webinos.org.

Jira issue: WP-959
