### PR TITLE
Fix enrolment in line with PZH user identity changes

### DIFF
--- a/lib/pzp_receiveMessage.js
+++ b/lib/pzp_receiveMessage.js
@@ -24,31 +24,27 @@ var PzpReceiveMessage = function () {
     var expectedPzhAddress;
 
     function registerBrowser(msg, connection) {
-      PzpObject.connectedApp(connection, msg.payload.value);
+        PzpObject.connectedApp(connection, msg.payload.value);
     }
 
     function beginPzpEnrollment(msg, connection) {
-        if (expectedPzhAddress === msg.payload.providerDetails) {
-            connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
-                "payload":{
-                  "status":"csrFromPzp",
-                  "csr":PzpObject.getCertificateToBeSignedByPzh(),
-                  "friendlyName": PzpObject.getFriendlyName()
-                }
-            }));
-        }
+        connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
+            "payload":{
+              "status":"csrFromPzp",
+              "csr":PzpObject.getCertificateToBeSignedByPzh(),
+              "friendlyName": PzpObject.getFriendlyName()
+            }
+        }));
     }
 
-    function endPzpEnrollment(msg) {
-        if (expectedPzhAddress === (msg.from && msg.from.split("_") && msg.from.split("_")[0])) {
-            PzpObject.pzpEnrollment (msg.from, msg.to, msg.payload.message);
-            PzpObject.connectHub();
-            expectedPzhAddress = "";
-            connection.sendUTF (JSON.stringify ({
-                "from":PzpObject.getDeviceName(), 
-                "payload":{"status":"enrolmentSuccess"}
-            }));
-        }
+    function endPzpEnrollment(msg, connection) {
+        PzpObject.pzpEnrollment (msg.from, msg.to, msg.payload.message);
+        PzpObject.connectHub();
+        expectedPzhAddress = "";
+        connection.sendUTF (JSON.stringify ({
+            "from":PzpObject.getDeviceName(), 
+            "payload":{"status":"enrolmentSuccess"}
+        }));
     }
 
     function changePzpCertificate(msg, connection) {

--- a/lib/pzp_receiveMessage.js
+++ b/lib/pzp_receiveMessage.js
@@ -31,7 +31,7 @@ var PzpReceiveMessage = function () {
         if (expectedPzhAddress === msg.payload.providerDetails) {
             connection.sendUTF (JSON.stringify ({"from":PzpObject.getDeviceName(),
                 "payload":{
-                  "status":"csrAuthCodeByPzp",
+                  "status":"csrFromPzp",
                   "csr":PzpObject.getCertificateToBeSignedByPzh(),
                   "friendlyName": PzpObject.getFriendlyName()
                 }
@@ -44,6 +44,10 @@ var PzpReceiveMessage = function () {
             PzpObject.pzpEnrollment (msg.from, msg.to, msg.payload.message);
             PzpObject.connectHub();
             expectedPzhAddress = "";
+            connection.sendUTF (JSON.stringify ({
+                "from":PzpObject.getDeviceName(), 
+                "payload":{"status":"enrolmentSuccess"}
+            }));
         }
     }
 
@@ -88,7 +92,7 @@ var PzpReceiveMessage = function () {
     }
 
     function setPzhAddress(msg) {
-        expectedPzhAddress = msg.payload.message;
+        expectedPzhAddress = "https://" + msg.payload.message;
     }
 
     function foundServices(msg){
@@ -133,7 +137,7 @@ var PzpReceiveMessage = function () {
 
     var methods= {
         "registerBrowser"      :registerBrowser,
-        "authCodeByPzh"        :beginPzpEnrollment,
+        "enrolRequestCSR"      :beginPzpEnrollment,
         "signedCertByPzh"      :endPzpEnrollment,
         "pzpId_Update"         :changePzpCertificate,
         "resetDevice"          :unRegisterDevice,
@@ -159,7 +163,7 @@ var PzpReceiveMessage = function () {
            PzpCommon.wUtil.webinosMsgProcessing.processedMsg(PzpObject, msg, function() {
            });
         }
-        PzpObject.handleProcessedMessage(msg, connection);
+        PzpObject.handleProcessedMessage(msg, origin, connection);
     };
 
     /**
@@ -180,13 +184,30 @@ var PzpReceiveMessage = function () {
         }
     };
 
-    this.handleProcessedMessage = function(validMsgObj, conn) {
+    function isSameOriginString(urlStringA, urlStringB) {
+        var url = require('url');
+        return isSameOrigin(url.parse(urlStringA), url.parse(urlStringB));
+    }
+
+    function isSameOrigin(urlA, urlB) {
+        return  urlA.protocol === urlB.protocol && 
+                urlA.port     === urlB.port &&
+                urlA.hostname === urlB.hostname;  
+    }
+    function validEnrolment(msg, origin, expectedAddress) {
+        return msg.payload.status === "setPzhProviderAddress" || // it's an initial message which can come from any origin
+            (isSameOriginString(origin, expectedAddress) &&      // OR it's from the origin we expected
+                (msg.payload.status === "enrolRequestCSR" ||     //   and it's an enrolment request
+                    msg.payload.status === "signedCertByPzh"));  //   or it's a set of signed certificates.
+    }
+
+    this.handleProcessedMessage = function(validMsgObj, origin, conn) {
         logger.log ("msg received " + JSON.stringify (validMsgObj));
         if (PzpObject.checkConnectedPzh(validMsgObj.from)    || // Currently Connected PZH
             PzpObject.checkConnectedPzp(validMsgObj.from)    || // Currently Connected PZPs
             PzpObject.checkConnectedWebApp(validMsgObj.from) || // Currently Connected PZH
             validMsgObj.payload.status === "registerBrowser" || // Special exception as this is first msg from browser
-            expectedPzhAddress                               || // Enrollment message comes from this address
+            validEnrolment(validMsgObj, origin, expectedPzhAddress) || // Enrollment message comes from this address
             PzpObject.checkTrustedList(validMsgObj.from)   // Entities that are trusted might in same zone or outside zone
             ){
             if (validMsgObj.type === "prop") {
@@ -195,7 +216,7 @@ var PzpReceiveMessage = function () {
                 PzpObject.messageHandler.onMessageReceived (validMsgObj, validMsgObj.to);
             }
         } else {
-            logger.log("Message from "+validMsgObj.from+" unconnected entity");
+            logger.log("Message from "+validMsgObj.from+" invalid or disconnected entity");
         }
     }
 

--- a/lib/pzp_receiveMessage.js
+++ b/lib/pzp_receiveMessage.js
@@ -171,7 +171,7 @@ var PzpReceiveMessage = function () {
         try {
             conn.pause (); // This pauses socket, cannot receive messages
             PzpCommon.wUtil.webinosMsgProcessing.readJson(PzpObject, buffer, function (validMsgObj) {
-                PzpObject.handleProcessedMessage(validMsgObj, conn);
+                PzpObject.handleProcessedMessage(validMsgObj, "TLS", conn);
             });
         } catch (err) {
             PzpObject.emit("EXCEPTION", new Error("failed in processing message received" + err));

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -173,7 +173,7 @@ function Pzp(inputConfig) {
         config.cert.internal.pzh.cert    = payload.masterCert;
         config.cert.crl.value            = payload.masterCrl;
         config.metaData.pzhId            = from;
-        config.metaData.serverName       = from && from.split ("_")[0];
+        config.metaData.serverName       = from && from.split ("@")[1];
         if((signedCert = config.cert.generateSignedCertificate(config.cert.internal.conn.csr))) {
             logger.log("connection signed certificate by PZP");
             config.cert.internal.conn.cert = signedCert;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "webinos-pzp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Webinos device functionality is implemented in PZP",
   "main": "./lib/pzp_sessionHandling.js",
   "author": "Habib Virji  <habib.virji@samsung.com>",

--- a/test/jasmine/pzp.spec.js
+++ b/test/jasmine/pzp.spec.js
@@ -32,6 +32,7 @@ var webinos;
 var numberOfPZP,numberOfPZH;
 numberOfPZH= 2; // Change this value if you do not like 100 PZPs to be created
 numberOfPZP = 2;
+var USER_DOMAIN = "localhost";
 
 var RSA_START       = "-----BEGIN RSA PRIVATE KEY-----";
 var RSA_END         = "-----END RSA PRIVATE KEY-----";
@@ -107,13 +108,16 @@ function createPzhProvider() {
 }
 
 function createPzh(pzhConnection, email, displayName) {
+    var nickname = email.split("@")[0]
     var user = {
         emails: [{value:email}],
         displayName: displayName,
-        from: "google"
+        from: "google",
+        nickname:nickname, 
+        identifier:nickname+"@"+USER_DOMAIN
     };
-    pzhConnection.write(wUtil.webinosMsgProcessing.jsonStr2Buffer(JSON.stringify({user: user, message: {type: "addPzh"}})));
-    return user;
+    pzhConnection.write(wUtil.webinosMsgProcessing.jsonStr2Buffer(JSON.stringify({user: user, message: {type: "addPzh", "nickname":nickname}})));
+    return nickname + "@" + USER_DOMAIN;
 }
 
 function createPzp(i, callback ) {
@@ -130,7 +134,7 @@ function createPzp(i, callback ) {
 
 function enrollPzp(pzhConnection, user, pzpInstance) {
     var msg = {user: user,
-        message: {type:"csrAuthCodeByPzp",
+        message: {type:"csrFromPzp",
             from:pzpInstance.getDeviceName(),
             csr:pzpInstance.getCertificateToBeSignedByPzh(),
             friendlyName: pzpInstance.getFriendlyName()}};
@@ -329,18 +333,17 @@ describe("PZH - PZP connectivity, enrollment, and findService at PZH", function(
             pzhConnection = require("tls").connect(pzpInstance.getWebinosPorts().provider,pzhAddress, pzhWebCertificates,
             function () {
                 expect(pzhConnection.authorized).toEqual(true);
-                user = createPzh(pzhConnection, "hello0@webinos.org", "Hello#0");
+                user = createPzh(pzhConnection, "hello0@"+USER_DOMAIN, "Hello#0");
             });
             pzhConnection.on("data", function (_buffer) {
                 wUtil.webinosMsgProcessing.readJson(this, _buffer, function (obj) {
                     if(obj.payload && obj.payload.type && obj.payload.type === "addPzh") {
                        enrollPzp(pzhConnection, user, pzpInstance);
                     } else if (obj.payload && obj.payload.message && obj.payload.message.payload && obj.payload.message.payload.status === "signedCertByPzh"){
-                        expect(obj.user.emails[0].value).toEqual("hello0@webinos.org");
-                        expect(obj.user.displayName).toEqual("Hello#0");
-                        expect(obj.payload.type).toEqual("csrAuthCodeByPzp");
-                        expect(obj.payload.message.from).toEqual(pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"_hello0@webinos.org");
-                        expect(obj.payload.message.to).toEqual(pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"_hello0@webinos.org/"+pzpInstance.getDeviceName());
+                        expect(obj.user).toEqual("hello0@"+USER_DOMAIN);
+                        expect(obj.payload.type).toEqual("csrFromPzp");
+                        expect(obj.payload.message.from).toEqual("hello0@"+pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer);
+                        expect(obj.payload.message.to).toEqual("hello0@"+pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"/"+pzpInstance.getDeviceName());
                         expect(obj.payload.message.payload.status).toEqual("signedCertByPzh");
                         expect(obj.payload.message.payload.message.clientCert).not.toBeNull();
                         expect(obj.payload.message.payload.message.clientCert).toContain(CERT_START);
@@ -368,7 +371,7 @@ describe("PZH - PZP connectivity, enrollment, and findService at PZH", function(
     });
     it("Find service at the PZH", function(done){
         setTimeout(function() {
-            findService(pzhAddress+":"+providerWebServer + "_hello0@webinos.org",function(status){
+            findService("hello0@"+pzhAddress+":"+providerWebServer,function(status){
                 if (status) done();
             })
         }, 50);// the update message that PZP sends take time to reach websocket client...
@@ -379,7 +382,7 @@ describe("PZH - PZP connectivity, enrollment, and findService at PZH", function(
 // Enroll multiple PZPs at a PZH
 describe("Create "+numberOfPZP+" PZP and Enroll with the Same PZH ", function(){
    it("Create "+numberOfPZP+" PZPs", function(done){
-       var user = {emails: [{value:"hello0@webinos.org"}],displayName: "Hello#0",from: "google"};
+       var user = {emails: [{value:"hello0@"+USER_DOMAIN}],displayName: "Hello#0",from: "google", nickname:"hello0", identifier:"hello0@"+USER_DOMAIN};
        function createPzpEnroll(i) {
           createPzp(i, function(pzpInstance){
               var pzhConnection = require("tls").connect(providerPort, pzhAddress, pzhWebCertificates,
@@ -390,8 +393,8 @@ describe("Create "+numberOfPZP+" PZP and Enroll with the Same PZH ", function(){
                   pzhConnection.on("data", function (_buffer) {
                       wUtil.webinosMsgProcessing.readJson(this, _buffer, function (obj) {
                           if (obj&& obj.payload && obj.payload.message && obj.payload.message.payload && obj.payload.message.payload.status === "signedCertByPzh"){
-                              expect(obj.payload.message.from).toEqual(pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"_hello0@webinos.org");
-                              expect(obj.payload.message.to).toEqual(pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"_hello0@webinos.org/"+pzpInstance.getDeviceName());
+                              expect(obj.payload.message.from).toEqual("hello0@"+pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer);
+                              expect(obj.payload.message.to).toEqual("hello0@"+pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"/"+pzpInstance.getDeviceName());
                               expect(obj.payload.message.payload.status).toEqual("signedCertByPzh");
                               expect(obj.payload.message.payload.message.clientCert).toContain(CERT_START);
                               expect(obj.payload.message.payload.message.masterCert).toContain(CERT_START);
@@ -400,7 +403,7 @@ describe("Create "+numberOfPZP+" PZP and Enroll with the Same PZH ", function(){
                               pzpInstance.connectHub();
                               pzpInstance.on("HUB_CONNECTED", function(){
                                   setTimeout(function(){
-                                      var addressLookService = pzhAddress+":"+providerWebServer + "_hello0@webinos.org/machine_"+ ((i === 0 )?0: (i-1)); // Find Service at other PZP
+                                      var addressLookService = "hello0@" + pzhAddress+":"+providerWebServer + "/machine_"+ ((i === 0 )?0: (i-1)); // Find Service at other PZP
                                       findService(addressLookService,function(){
                                           pzhConnection.socket.end();
                                           if ((i+1) < numberOfPZP) createPzpEnroll(i + 1);
@@ -424,11 +427,10 @@ describe("Create Multiple PZH and do certificate exchange between them", functio
         function createPzh_Pzp(i) {
             var socket = require("tls").connect(providerPort,pzhAddress, pzhWebCertificates,
                 function() {
-                    var  pzpInstance, user = createPzh(socket, "hello"+i+"@webinos.org", "Hello#"+ i);
+                    var  pzpInstance, user = createPzh(socket, "hello"+i+"@"+USER_DOMAIN, "Hello#"+ i);
                     socket.on("data", function (_buffer) {
                         wUtil.webinosMsgProcessing.readJson(this, _buffer, function (obj) {
                             if(obj.payload && obj.payload.type && obj.payload.type === "addPzh") {
-                                expect(user.emails[0].value).toEqual(obj.payload.message.split("_")[1]);
                                 createPzp(numberOfPZP+i, function(pzpInstance_){
                                     pzpInstance = pzpInstance_;
                                     enrollPzp(socket, user, pzpInstance);
@@ -450,15 +452,15 @@ describe("Create Multiple PZH and do certificate exchange between them", functio
         }
         createPzh_Pzp(1);  // 0 is first PZH that's created already
     });
-    it("Connect PZH (hello0@webinos.org) to all PZHs we have created", function(done) {
+    it("Connect PZH (hello0@"+USER_DOMAIN+") to all PZHs we have created", function(done) {
         // Certificate Exchange between PZH0 to PZH1
         // Connect everyone to PZH0 as we have only access to this PZH's PZP's WRT...
         function connectPZH(i) {
             var msg, socket = require("tls").connect(providerPort,pzhAddress, pzhWebCertificates,
                 function() {
-                    var user = {emails: [{value:"hello0@webinos.org"}], displayName: "Hello#0",  from: "google"};
+                    var user = {emails: [{value:"hello0@"+USER_DOMAIN}], displayName: "Hello#0",  from: "google", nickname:"hello0", identifier:"hello0@"+USER_DOMAIN};
                     // hello0@webinos.org connect to all PZHs
-                    msg = {user: user, message: {type: "requestAddLocalFriend", "externalEmail":"hello"+i+"@webinos.org"}};
+                    msg = {user: user, message: {type: "requestAddLocalFriend", "externalNickname":"hello"+i}};
                     socket.write(wUtil.webinosMsgProcessing.jsonStr2Buffer(JSON.stringify(msg)));
                     socket.on("data", function (_buffer) {
                         wUtil.webinosMsgProcessing.readJson(this, _buffer, function (obj) {
@@ -476,13 +478,13 @@ describe("Create Multiple PZH and do certificate exchange between them", functio
         connectPZH(1);
     });
 
-    it("Approve at all PZH, request from hello0@webinos.org", function(done){
+    it("Approve at all PZH, request from hello0@"+USER_DOMAIN, function(done){
         function approvePZH(i) {
             var msg, socket = require("tls").connect(providerPort,pzhAddress, pzhWebCertificates,
                 function() {
-                    var user = {emails: [{value:"hello"+i+"@webinos.org"}], displayName: "Hello#"+i,  from: "google"};
+                    var user = {emails: [{value:"hello"+i+"@"+USER_DOMAIN}], displayName: "Hello#"+i,  from: "google", "nickname":"hello"+i, "identifier":"hello"+i+"@"+USER_DOMAIN};
                     // hello0@webinos.org connect to all PZHs
-                    msg = {user: user, message: {type: "approveFriend", "externalEmail":"hello0@webinos.org"}};
+                    msg = {user: user, message: {type: "approveFriend", "externalUserId":"hello0@"+USER_DOMAIN}};
                     socket.write(wUtil.webinosMsgProcessing.jsonStr2Buffer(JSON.stringify(msg)));
                     socket.on("data", function (_buffer) {
                         wUtil.webinosMsgProcessing.readJson(this, _buffer, function (obj) {
@@ -505,7 +507,7 @@ describe("Create Multiple PZH and do certificate exchange between them", functio
         // So findService from PZHA about PZHB services...
         function findServicePzp(i) {
             setTimeout(function(){
-                var address = pzhAddress+":"+providerWebServer + "_hello"+i+"@webinos.org/machine_"+ (numberOfPZP+i);
+                var address = "_hello"+i+"@"+pzhAddress+":"+providerWebServer +"/machine_"+ (numberOfPZP+i);
                 findService(address, function(status){
                     expect(status).toBeTruthy();
                     if ((i + 1) < numberOfPZH) findServicePzp(i+1);
@@ -520,7 +522,7 @@ describe("Create Multiple PZH and do certificate exchange between them", functio
 
 describe("machine with long Pzp Name", function(){
    it("create pzp with long name and enroll with pzh", function(done){
-       var user = {emails: [{value:"hello0@webinos.org"}],displayName: "Hello#0",from: "google"};
+       var user = {emails: [{value:"hello0@"+USER_DOMAIN}],displayName: "Hello#0",from: "google", nickname:"hello0", identifier:"hello0@"+USER_DOMAIN};
 
        var inputConfig = {
            "friendlyName":"Linux Device #longName",
@@ -535,8 +537,8 @@ describe("machine with long Pzp Name", function(){
                pzhConnection.on("data", function (_buffer) {
                    wUtil.webinosMsgProcessing.readJson(this, _buffer, function (obj) {
                        if (obj&& obj.payload && obj.payload.message && obj.payload.message.payload && obj.payload.message.payload.status === "signedCertByPzh"){
-                           expect(obj.payload.message.from).toEqual(pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"_hello0@webinos.org");
-                           expect(obj.payload.message.to).toEqual(pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"_hello0@webinos.org/"+pzpInstance.getDeviceName());
+                           expect(obj.payload.message.from).toEqual("hello0@"+pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer);
+                           expect(obj.payload.message.to).toEqual("hello0@"+pzhAddress+":"+pzpInstance.getWebinosPorts().provider_webServer+"/"+pzpInstance.getDeviceName());
                            expect(obj.payload.message.payload.status).toEqual("signedCertByPzh");
                            expect(obj.payload.message.payload.message.clientCert).toContain(CERT_START);
                            expect(obj.payload.message.payload.message.masterCert).toContain(CERT_START);
@@ -545,7 +547,7 @@ describe("machine with long Pzp Name", function(){
                            pzpInstance.connectHub();
                            pzpInstance.on("HUB_CONNECTED", function(){
                                setTimeout(function(){
-                                   var addressLookService = pzhAddress+":"+providerWebServer + "_hello0@webinos.org"; // Find Service at PZH
+                                   var addressLookService = "hello0@"+pzhAddress+":"+providerWebServer; // Find Service at PZH
                                    findService(addressLookService,function(){
                                      pzhConnection.socket.end();
                                      done();


### PR DESCRIPTION
A number of changes at the PZH and PZH web server mean that
the PZP was not enrolling properly.  This has now been fixed.

In addition, the PZP will now report when enrolment was a
success or not (at least in some cases) and the new PZH and PZHWS
code should be a bit friendlier.

This is strongly linked to changes in the PZH and PZHWS.

Jira issue: WP-959
