### PR TITLE
Wp 1045 register service constructors

### DIFF
--- a/node_modules/webinos-api-test/wrt/webinos.get42.js
+++ b/node_modules/webinos-api-test/wrt/webinos.get42.js
@@ -23,16 +23,14 @@
 	 * @param obj Object containing displayName, api, etc.
 	 */
 	TestModule = function(obj) {
-		this.base = WebinosService;
-		this.base(obj);
+		WebinosService.call(this, obj);
 		
 		this._testAttr = "HelloWorld";
 		this.__defineGetter__("testAttr", function (){
 			return this._testAttr + " Success";
 		});
 	};
-	
-	TestModule.prototype = new WebinosService;
+	_webinos.registerServiceConstructor("http://webinos.org/api/test", TestModule);
 	
 	/**
 	 * To bind the service.

--- a/wrt/webinos.js
+++ b/wrt/webinos.js
@@ -16,7 +16,6 @@
  * Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
  ******************************************************************************/
 (function () {
-    if (typeof webinos === "undefined") webinos = {};
     var channel = null;
 
     /**

--- a/wrt/webinos.session.js
+++ b/wrt/webinos.session.js
@@ -17,8 +17,11 @@
  * Copyright 2012 - 2013 Samsung Electronics (UK) Ltd
  * Authors: Habib Virji
  ******************************************************************************/
-if (typeof webinos === "undefined") var webinos = {};
-if (typeof webinos.session === "undefined") webinos.session = {};
+if (typeof exports.webinos === "undefined") exports.webinos = {};
+if (typeof exports.webinos.session === "undefined") exports.webinos.session = {};
+
+if (typeof _webinos === "undefined") var _webinos = {};
+
 (function() {
     "use strict";
 

--- a/wrt/webinos.session.js
+++ b/wrt/webinos.session.js
@@ -17,10 +17,14 @@
  * Copyright 2012 - 2013 Samsung Electronics (UK) Ltd
  * Authors: Habib Virji
  ******************************************************************************/
+if (typeof exports === "undefined") exports = window;
 if (typeof exports.webinos === "undefined") exports.webinos = {};
 if (typeof exports.webinos.session === "undefined") exports.webinos.session = {};
 
-if (typeof _webinos === "undefined") var _webinos = {};
+if (typeof _webinos === "undefined") {
+    _webinos = {};
+    _webinos.registerServiceConstructor = function(){};
+}
 
 (function() {
     "use strict";


### PR DESCRIPTION
The name for API module constructors is no longer hard coded, so APIs
have to register

Jira-issue: http://jira.webinos.org/browse/WP-1045
