### PR TITLE
remove null arg from storeDetails call

### DIFF
--- a/lib/pzp_peerCertificateExchange.js
+++ b/lib/pzp_peerCertificateExchange.js
@@ -51,7 +51,7 @@ function PeerCertificateExchange(PzpInstance) {
                 if(!parent.config.exCertList.hasOwnProperty(msg.from)) {
                     var storepzp = {"exPZP" : msg.from};
                     parent.config.exCertList = storepzp;
-                    parent.config.storeDetails(null, "exCertList", parent.config.exCertList);
+                    parent.config.storeDetails("exCertList", parent.config.exCertList);
                 }
 
                 //send own certificate back
@@ -269,7 +269,7 @@ function PeerCertificateExchange(PzpInstance) {
                             if(!parent.config.exCertList.hasOwnProperty(rmsg.from)) {
                                 var storepzp = {"exPZP" : rmsg.from};
                                 parent.config.exCertList = storepzp;
-                                parent.config.storeDetails(null, "exCertList", parent.config.exCertList);
+                                parent.config.storeDetails("exCertList", parent.config.exCertList);
                             }
                             var msg={};
                             logger.log("rmsg.from: " + rmsg.from);

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -218,7 +218,7 @@ function Pzp(inputConfig) {
                         logger.log ("*****"+config.metaData.webinosType+" Connection Certificate Signed by Master Certificate*****");
                         config.cert.internal.conn.cert = signedCert;
                         config.storeDetails(PzpCommon.path.join("certificates", "internal"),"certificates", config.cert.internal);
-                        config.storeDetails(null, "crl", config.cert.crl);
+                        config.storeDetails("crl", config.cert.crl);
                         return true;
                     }
                 }


### PR DESCRIPTION
fixes exception on path.join with node.js 0.10, which doesn't allow any
other args than strings.

Jira-issue: http://jira.webinos.org/browse/WP-980
