### PR TITLE
Fix the PZP to support enrolment on non-standard PZH ports

### DIFF
--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -170,6 +170,7 @@ function Pzp(inputConfig) {
         config.cert.crl.value            = payload.masterCrl;
         config.metaData.pzhId            = from;
         config.metaData.serverName       = from && from.split ("@")[1];
+        
         if((signedCert = config.cert.generateSignedCertificate(config.cert.internal.conn.csr))) {
             logger.log("connection signed certificate by PZP");
             config.cert.internal.conn.cert = signedCert;
@@ -186,12 +187,15 @@ function Pzp(inputConfig) {
                 config.metaData.serverName = config.metaData.serverName.split (":")[0];
             }
 
+            config.userPref.ports.provider   = payload.serverPort;
+            
             if (!config.trustedList.pzh.hasOwnProperty (config.metaData.pzhId)) {
                 config.trustedList.pzh[config.metaData.pzhId] = {friendlyName: payload.friendlyName};
             }
             pzpState.enrolled = true;
             pzpState.sessionId = PzpObject.setSessionId(); // IMP during enrollment sessionId changes..
             PzpObject.setFriendlyName(config.metaData.friendlyName);
+            config.storeDetails("userData", "userPref", config.userPref);
             config.storeDetails("metaData", config.metaData);
             config.storeDetails("crl", config.crl);
             config.storeDetails("trustedList", config.trustedList);

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -39,22 +39,23 @@ function PzpWebSocketServer(){
     /**
      * This handles HTTP request which includes file which are shown in browser
      */
-    function handleHttpRequest(uri, req, res) {
+    function handleHttpRequest(url, req, res) {
         /**
          * Expose the current communication channel websocket port using this virtual file.
          * This code must have the same result with the widgetServer.js used by wrt
          * webinos\common\manager\widget_manager\lib\ui\widgetServer.js
          */
-        var parts = uri.split('/').filter(function (part) { return !!part; });
+        var path = url.pathname;
+        var parts = path.split('/').filter(function (part) { return !!part; });
         if (parts.length >= 2 && parts[0] == "module" && moduleHttpHandlers[parts[1]]) {
             return moduleHttpHandlers[parts[1]](req, res);
-        } else if (uri == "/webinosConfig.json") {
+        } else if (path == "/webinosConfig.json") {
             var jsonReply =
             res.writeHead (200, {"Content-Type":"application/json"});
             res.write (JSON.stringify ({websocketPort:PzpObject.getWebinosPorts("pzp_webSocket")}));
             res.end();
             return;
-        } else if (uri === "/promptReply") {
+        } else if (path === "/promptReply") {
             try {
                 if (require.resolve("webinos-policy")) {
                     var pm_rpc = require(PzpCommon.path.join(require.resolve("webinos-policy"), "../../lib/rpcInterception.js"));
@@ -68,16 +69,16 @@ function PzpWebSocketServer(){
                 logger.error("error during prompt reply: " + err.message);
             }
             return;
-        } else if (/^\/dashboard(\/.*)?$/.test(uri)) {
+        } else if (/^\/dashboard(\/.*)?$/.test(path)) {
             var dashboard = null;
             try {dashboard = require("webinos-dashboard");}catch (e){logger.log("webinos Dashboard is not present.");}
             if (dashboard != null){
-                dashboard.httpHandler(uri, req, res);
+                dashboard.httpHandler(path, req, res);
                 return;
             }
         }
         var documentRoot = PzpCommon.path.join (__dirname, "../web_root/");
-        var filename = PzpCommon.path.join (documentRoot, uri);
+        var filename = PzpCommon.path.join (documentRoot, path);
         // If we detect that user has not configured PZP, redirect towards the page.
         PzpCommon.wUtil.webinosContent.sendFile(res, documentRoot, filename, "index.html");
     }
@@ -201,7 +202,7 @@ function PzpWebSocketServer(){
                     peerCert.handleMsg(parsed);
                 }
             });
-            handleHttpRequest(parsed.pathname, request, response);
+            handleHttpRequest(parsed, request, response);
         });
 
         httpserver.on ("error", function (err) {


### PR DESCRIPTION
The PZP was always attempting to enrol using port 80.  Now it obeys the PZH
when it tells it to use a different port.

Required support PR: https://github.com/webinos/webinos-pzh/pull/16

Jira issue: WP-852
