### PR TITLE
Fix PZP crash while building webinos.js

### DIFF
--- a/lib/pzp_serviceHandler.js
+++ b/lib/pzp_serviceHandler.js
@@ -75,7 +75,7 @@ var PzpServiceHandler = function () {
             , hostname : PzpObject.getPzpHost()
             }
           }, PzpObject.moduleHttpHandlers); // load specified modules
-        PzpCommon.wUtil.webinosService.createWebinosJS(nodeModulesPath, PzpObject.getServiceCache()); // Creates initial webinosJSPzp
+        PzpCommon.wUtil.webinosService.createWebinosJS(nodeModulesPath, newModules); // Creates initial webinosJSPzp
     }
 
     function updateServiceCache (validMsgObj, remove) {


### PR DESCRIPTION
webinos.js must be built from modules available on the local system only instead of list of modules from serviceCache. Fix crash on PZP start when the PZP was enrolled to a PZH.

Jira-issue: WP-1034
