### PR TITLE
Add policy enforcement tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,33 +1,37 @@
-{ "name": "webinos-pzp",
+{
+  "name": "webinos-pzp",
   "version": "0.8.2",
   "description": "Webinos device functionality is implemented in PZP",
   "main": "./lib/pzp_sessionHandling.js",
   "author": "Habib Virji  <habib.virji@samsung.com>",
   "homepage": "http://www.webinos.org",
   "bugs": "http://jira.webinos.org",
-  "repository":
-   { "type": "git",
-     "url": "git://github.com/webinos/webinos-pzp.git"
-   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/webinos/webinos-pzp.git"
+  },
   "directories": {
     "lib": "./lib",
     "node_modules": "./node_modules",
-    "test":"./test"
+    "test": "./test"
   },
-  "bundleDependencies":["webinos-api-test"],
-  "dependencies":{
+  "bundleDependencies": [
+    "webinos-api-test"
+  ],
+  "dependencies": {
     "webinos-certificateHandler": "git://github.com/webinos/webinos-certificateHandler.git",
-    "webinos-utilities"         : "git://github.com/webinos/webinos-utilities.git",
-    "webinos-messaging"         : "git://github.com/webinos/webinos-messaging.git",
-    "webinos-policy"            : "git://github.com/webinos/webinos-policy.git",
-    "webinos-synchronization"   : "git://github.com/webinos/webinos-synchronization.git",
-    "webinos-api-serviceDiscovery":"git://github.com/webinos/webinos-api-serviceDiscovery.git",
-    "webinos-jsonrpc2"   : "*",
+    "webinos-utilities": "git://github.com/webinos/webinos-utilities.git",
+    "webinos-messaging": "git://github.com/webinos/webinos-messaging.git",
+    "webinos-policy": "git://github.com/webinos/webinos-policy.git",
+    "webinos-synchronization": "git://github.com/webinos/webinos-synchronization.git",
+    "webinos-api-serviceDiscovery": "git://github.com/webinos/webinos-api-serviceDiscovery.git",
+    "webinos-jsonrpc2": "*",
     "websocket": "1.0.2",
     "optimist": "x.x.x"
   },
   "devDependencies": {
-    "jasmine-node": "1.x.x"
+    "jasmine-node": "1.x.x",
+    "zombie": "~2.0.0-alpha19"
   },
   "engines": {
     "node": ">= 0.6.0",

--- a/test/policy/README.MD
+++ b/test/policy/README.MD
@@ -1,0 +1,9 @@
+Instructions
+===========
+
+Use this script under Linux.
+
+ # Make sure you've backed up your ~/.webinos directory
+ # Go to the webinos-pzp directory
+ # Run "./test/policy/run.sh"
+ # If the result is "TEST PASSED" then the test passed.

--- a/test/policy/deny-all.xml
+++ b/test/policy/deny-all.xml
@@ -1,0 +1,20 @@
+<policy id="p1" combine="first-applicable" description="catch">
+	<rule effect="permit">
+			<condition combine="or">
+				<resource-match attr="api-feature" match="http://webinos.org/api/discovery"/>
+			</condition>
+	</rule>	
+	<DataHandlingPreferences PolicyId="#DHP_allow_all">
+		<AuthorizationsSet>
+			<AuthzUseForPurpose>
+					<Purpose/>
+			</AuthzUseForPurpose>
+		</AuthorizationsSet>
+	</DataHandlingPreferences>
+	<ProvisionalActions>
+		<ProvisionalAction>
+			<AttributeValue>#DHP_allow_all</AttributeValue>
+			<AttributeValue>*</AttributeValue>
+		</ProvisionalAction>
+	</ProvisionalActions>
+</policy>

--- a/test/policy/permit-all.xml
+++ b/test/policy/permit-all.xml
@@ -1,0 +1,16 @@
+<policy id="p1" combine="first-applicable" description="catch">
+	<rule id="r1" effect="permit"></rule>
+	<DataHandlingPreferences PolicyId="#DHP_allow_all">
+		<AuthorizationsSet>
+			<AuthzUseForPurpose>
+					<Purpose/>
+			</AuthzUseForPurpose>
+		</AuthorizationsSet>
+	</DataHandlingPreferences>
+	<ProvisionalActions>
+		<ProvisionalAction>
+			<AttributeValue>#DHP_allow_all</AttributeValue>
+			<AttributeValue>*</AttributeValue>
+		</ProvisionalAction>
+	</ProvisionalActions>
+</policy>

--- a/test/policy/run.sh
+++ b/test/policy/run.sh
@@ -1,0 +1,82 @@
+#! /bin/bash
+################################################################################
+#  Code contributed to the webinos project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2013 John Lyle, University of Oxford
+################################################################################
+
+# To be run from the root directory of the PZP module
+
+# Fail if anything fails
+set -e
+
+export PZP_DIR=`pwd`
+export TESTDIR=$PZP_DIR/test/policy
+export WEBINOSJS=$PZP_DIR/web_root/webinos.js
+export WEBINOSJSCP=$TESTDIR/webinos.js
+
+# copy the webinos.js file into this directory
+if [ -e "$WEBINOSJSCP" ]; then
+  rm $WEBINOSJSCP
+  echo "Deleted file $WEBINOSJSCP"
+fi
+echo "copying webinos.js"
+cp -v $WEBINOSJS $WEBINOSJSCP
+
+sleep 2
+
+# run the PZP in test mode, to creat initial directories
+node ./webinos_pzp.js --test
+sleep 2
+
+# Remove the policy file
+if [ -e "~/.webinos/policies/policy.xml" ]; then
+  echo "remove policy.xml"
+  rm ~/.webinos/policies/policy.xml
+fi
+
+# upload a deny-all policy
+echo "Setting a deny-all policy"
+cp $TESTDIR/deny-all.xml ~/.webinos/policies/policy.xml
+
+# start the PZP
+echo "Starting the PZP"
+node ./webinos_pzp.js &
+
+export PZP_PID=$!
+
+# wait 5 secs for it to start
+sleep 5
+echo "Started the PZP and waited" 
+
+set +e
+
+# run the node test script
+# note that we're in the webinos-pzh directory at the moment.
+node $TESTDIR/zombietest.deny.spec.js
+
+export TEST_RESULT=$?
+
+echo "Killing the PZP"
+# Kill the PZP
+kill -9 $PZP_PID
+
+if [ $TEST_RESULT ]; then
+  echo "TEST PASSED"
+else 
+  echo "TEST FAILED"
+fi
+
+exit $TEST_RESULT

--- a/test/policy/run.sh
+++ b/test/policy/run.sh
@@ -73,7 +73,7 @@ echo "Killing the PZP"
 # Kill the PZP
 kill -9 $PZP_PID
 
-if [ $TEST_RESULT ]; then
+if [ $TEST_RESULT -eq 0 ]; then
   echo "TEST PASSED"
 else 
   echo "TEST FAILED"

--- a/test/policy/testdeny.html
+++ b/test/policy/testdeny.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <title>Testing policies: all policies deny</title>
+    <script type="text/javascript" src="webinos.js"></script>
+    <script type="text/javascript">
+
+    var helloService = null;
+
+    function doSuccess() {
+      document.getElementById("testResult").textContent = "Success!";
+    }
+
+    function doFailure(err) {
+      document.getElementById("testResult").textContent = "Failed: " + JSON.stringify(err);
+    }
+
+    function invokeGet42(service) {
+      try {
+        service.get42(null, doSuccess, doFailure);
+      } catch (err) {
+        doFailure(err);
+      }
+    }
+
+    function serviceBound(service) {
+      helloService = service;
+      console.log("Bound!");
+      invokeGet42(service);
+    }
+    function serviceFound(service) {
+		  console.log("We've found a service! Name: " + service.displayName );
+      service.bindService({ onBind: serviceBound });
+		}
+		function findTestService() {
+		  webinos.discovery.findServices(
+		    new ServiceType('http://webinos.org/api/test'),
+		    { onFound: serviceFound }
+		  );
+		}
+		window.onload = findTestService;
+    </script>
+  </head>
+  <body>
+  	<p id="testResult"> Test in progress.</p>
+  </body>
+</html>

--- a/test/policy/zombietest.deny.spec.js
+++ b/test/policy/zombietest.deny.spec.js
@@ -1,0 +1,54 @@
+/*******************************************************************************
+*  Code contributed to the webinos project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Copyright 2013 John Lyle, University of Oxford
+*******************************************************************************/
+
+var Browser = require("zombie");
+var assert = require("assert");
+var util = require('util');
+
+var testPath = "test/policy/testdeny.html"
+var testURL = "file://" + process.cwd() + "/" + testPath;
+
+console.log("Testing " + testURL);
+
+function waitFor(window) {
+  var res = window.document.getElementById("testResult").innerText.indexOf("Test in progress");
+  console.log("Testing: " + window.document.getElementById("testResult").innerText + ", === " + res);
+  return ( res < 0 );
+}
+  
+Browser.debug = false;
+Browser.silent = true;
+
+browser = new Browser()
+
+browser.visit(testURL).then(function() {
+  setTimeout(function() {
+    var result = JSON.stringify(browser.text("#testResult"));
+    if ( result.indexOf("Failed:") >= 0 && result.indexOf("SecurityError") >= 0 ) {
+      console.log("Successfully failed to connect");
+      process.exit(0);
+    } else {
+      console.log()
+      console.log("Test failed - " + result + " - " + browser.window.console.output);
+      process.exit(-1000);
+    }
+
+  }, 5000);
+});
+
+


### PR DESCRIPTION
This test does the following:
- Replaces the PZP's policy with a policy denying access to everything except service discovery
- Runs the PZP
- Uses zombiejs to load a browser, pointing to a page attempting to use the get42() function
- Returns 'success' if the page fails to use the API

Note that these tests are not integrated with Travis, yet, although they could very easily be.

Jira issue :WP-996
