### PR TITLE
Fix PZH Address syntax - add path

### DIFF
--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -164,13 +164,14 @@ function Pzp(inputConfig) {
      */
     this.pzpEnrollment = function (from, to, payload) {
         var signedCert;
+        var url = require('url');
         logger.log ("PZP ENROLLED AT  " + from);    // This message come from PZH web server over websocket
         config.cert.internal.master.cert = payload.clientCert;
         config.cert.internal.pzh.cert    = payload.masterCert;
         config.cert.crl.value            = payload.masterCrl;
         config.metaData.pzhId            = from;
         config.metaData.serverName       = from && from.split ("@")[1];
-        config.metaData.pzhWebAddress     = payload.webAddress;
+        config.metaData.pzhWebAddress    = url.format(url.parse(payload.webAddress));
         
         if((signedCert = config.cert.generateSignedCertificate(config.cert.internal.conn.csr))) {
             logger.log("connection signed certificate by PZP");

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -177,7 +177,6 @@ function PzpWebSocketServer(){
     };
 
     function sendApplicationItsId(msgType, to) {
-        var url = require('url');
         var msg, payload = { 
             "pzhId": PzpObject.getPzhId(),
             "connectedDevices" :getConnectedInfo(),

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -177,6 +177,7 @@ function PzpWebSocketServer(){
     };
 
     function sendApplicationItsId(msgType, to) {
+        var url = require('url');
         var msg, payload = { 
             "pzhId": PzpObject.getPzhId(),
             "connectedDevices" :getConnectedInfo(),


### PR DESCRIPTION
The PZH web address URL given by the PZH during enrolment did not have a trailing slash.  This meant that the 'invitations' redirect was failing.

Jira issue: WP-1084
