### PR TITLE
WP-1121: Building in APIs for Android.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,18 @@
     "webinos-api-applauncher"   : "git://github.com/webinos/webinos-api-applauncher.git",
     "webinos-jsonrpc2"          : "*",
     "websocket"                 : "1.0.2",
-    "optimist"                  : "x.x.x"
+    "optimist"                  : "x.x.x",
+    "webinos-api-deviceStatus": "git://github.com/webinos/webinos-api-deviceStatus.git",
+    "webinos-api-deviceDiscovery": "git://github.com/webinos/webinos-api-deviceDiscovery.git",
+    "webinos-api-deviceOrientation": "git://github.com/webinos/webinos-api-deviceOrientation.git",
+    "webinos-api-events": "git://github.com/webinos/webinos-api-events.git",
+    "webinos-api-app2app": "git://github.com/webinos/webinos-api-app2app.git",
+    "webinos-api-geolocation": "git://github.com/webinos/webinos-api-geolocation.git",
+    "webinos-api-file": "git://github.com/webinos/webinos-api-file.git",
+    "webinos-api-contacts": "git://github.com/webinos/webinos-api-contacts.git",
+    "webinos-api-sensors": "git://github.com/webinos/webinos-api-sensors.git",
+    "webinos-api-media": "git://github.com/webinos/webinos-api-media.git",
+    "webinos-api-nfc": "git://github.com/webinos/webinos-api-nfc.git"
   },
   "devDependencies": {
     "jasmine-node": "1.x.x"
@@ -32,7 +43,6 @@
     "node": ">= 0.6.0",
     "npm": ">= 1.1.17"
   },
-  "preferGlobal": true,
   "bin": {
     "webinos_pzp": "webinos_pzp.js"
   },


### PR DESCRIPTION
The APIs won't be manually installed.
To address the npm WARN, webinos-pzp doesn't need to be globally installed.
Jira issue: WP-1121
