### PR TITLE
Let PZP event handler know when connected to PZH

### DIFF
--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -199,6 +199,9 @@ function Pzp(inputConfig) {
             pzpState.state[type] = "connected";
             PzpObject.onConnect(id);
             PzpObject.emit(type.toUpperCase()+"_CONNECTED");
+            if (type === "Pzh") {
+                PzpObject.setConnectState(type, true);
+            }
         } else {
             PzpObject.unAuthorized(conn);
         }


### PR DESCRIPTION
Fixes app2app to not be registered on PZP when connected to PZH.

Jira-issue: http://jira.webinos.org/browse/WP-1161?focusedCommentId=14602#comment-14602
