### PR TITLE
WP-1175 emit generic uri events

### DIFF
--- a/lib/pzp_cleanup.js
+++ b/lib/pzp_cleanup.js
@@ -114,6 +114,13 @@ function Pzp_CleanUp(){
         });
         PzpObject.setConnectState("hub", false);
         PzpObject.initializePzp();
+
+        try {
+            require("webinos-policy").policyEvent.emit("updateEnrollmentStatus");
+        }
+        catch (e) {
+            logger.log(e);
+        }
     };
 
     this.decideToKeepConnectionAliveOrClose= function(id){

--- a/lib/pzp_cleanup.js
+++ b/lib/pzp_cleanup.js
@@ -115,11 +115,15 @@ function Pzp_CleanUp(){
         PzpObject.setConnectState("hub", false);
         PzpObject.initializePzp();
 
+        var pm = null;
         try {
-            require("webinos-policy").policyEvent.emit("updateEnrollmentStatus");
+            pm = require("webinos-policy");
         }
         catch (e) {
             logger.log(e);
+        }
+        if (pm) {
+            pm.policyEvent.emit("updateEnrollmentStatus");
         }
     };
 

--- a/lib/pzp_cleanup.js
+++ b/lib/pzp_cleanup.js
@@ -120,7 +120,7 @@ function Pzp_CleanUp(){
             pm = require("webinos-policy");
         }
         catch (e) {
-            logger.log(e);
+            logger.log("Policy Manager was not found");
         }
         if (pm) {
             pm.policyEvent.emit("updateEnrollmentStatus");

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -280,6 +280,12 @@ function Pzp(inputConfig) {
             config.storeDetails(require("path").join("certificates", "internal"), "certificates", config.cert.internal);
             PzpObject.connectOwnPzh();
         }
+        try {
+            require("webinos-policy").policyEvent.emit("updateEnrollmentStatus");
+        }
+        catch (e) {
+            logger.log(e);
+        }
     };
 
     this.createPzpCertificates = function() {

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -109,7 +109,7 @@ function Pzp(inputConfig) {
             pm = require("webinos-policy");
         }
         catch (e) {
-            logger.log(e);
+            logger.log("Policy Manager was not found");
         }
         if (pm) {
             pm.policyEvent.emit("updateFriends");
@@ -289,7 +289,7 @@ function Pzp(inputConfig) {
             pm = require("webinos-policy");
         }
         catch (e) {
-            logger.log(e);
+            logger.log("Policy Manager was not found");
         }
         if (pm) {
             pm.policyEvent.emit("updateEnrollmentStatus");

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -104,11 +104,15 @@ function Pzp(inputConfig) {
     this.updateTrustedList = function(value) {
         config.trustedList = value;
         config.storeDetails("trustedList", config.trustedList);
+        var pm = null;
         try {
-            require("webinos-policy").policyEvent.emit("updateFriends");
+            pm = require("webinos-policy");
         }
         catch (e) {
             logger.log(e);
+        }
+        if (pm) {
+            pm.policyEvent.emit("updateFriends");
         }
     };
     this.updateCRL         = function(value) {config.cert.crl.value = value; config.storeDetails("crl", config.cert.crl);};
@@ -280,11 +284,15 @@ function Pzp(inputConfig) {
             config.storeDetails(require("path").join("certificates", "internal"), "certificates", config.cert.internal);
             PzpObject.connectOwnPzh();
         }
+        var pm = null;
         try {
-            require("webinos-policy").policyEvent.emit("updateEnrollmentStatus");
+            pm = require("webinos-policy");
         }
         catch (e) {
             logger.log(e);
+        }
+        if (pm) {
+            pm.policyEvent.emit("updateEnrollmentStatus");
         }
     };
 

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  *  Code contributed to the webinos project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,7 +101,16 @@ function Pzp(inputConfig) {
     this.checkConnectedPzp = function(from) { return (pzpState.connectedPzp.hasOwnProperty(from) || pzpState.connectedDevicesToPzh.pzp.hasOwnProperty(from)); };
     // Change device name, this happens only when the name already exists in the zone, PZH instructs this name change.
     this.setDeviceName     = function(name) { config.metaData.webinosName = name; };
-    this.updateTrustedList = function(value) {config.trustedList = value; config.storeDetails("trustedList", config.trustedList);};
+    this.updateTrustedList = function(value) {
+        config.trustedList = value;
+        config.storeDetails("trustedList", config.trustedList);
+        try {
+            require("webinos-policy").policyEvent.emit("updateFriends");
+        }
+        catch (e) {
+            logger.log(e);
+        }
+    };
     this.updateCRL         = function(value) {config.cert.crl.value = value; config.storeDetails("crl", config.cert.crl);};
     this.getSignedCertificateObj = function(){ return (config.cert.internal.signedCert || "{}"                  ); };
     this.updateExternalCertificates = function(value) {
@@ -121,7 +130,7 @@ function Pzp(inputConfig) {
             }
         });
         PzpObject.addRemoteServices(extServ);
-    }; 
+    };
 
     this.updateWebinosPort = function(key, value) {config.userPref.ports[key] = value; config.storeDetails("userData", "userPref", config.userPref) };
     this.checkTrustedList = function(from) {
@@ -255,7 +264,7 @@ function Pzp(inputConfig) {
             }
 
             config.userPref.ports.provider   = payload.serverPort;
-            
+
             if (!config.trustedList.pzh.hasOwnProperty (config.metaData.pzhId)) {
                 config.trustedList.pzh[config.metaData.pzhId] = {friendlyName: payload.friendlyName, remoteAddress: config.metaData.serverName };
             }


### PR DESCRIPTION
http://jira.webinos.org/browse/WP-1175

The PZP sends events to the policy manager to notify when the PZP is enrolled/unRegistered and when the connected PZHs list is updated. This data is required to manage generic URIs.
