### PR TITLE
Wp 1221 pzh functionality fixes

### DIFF
--- a/lib/pzp_cleanup.js
+++ b/lib/pzp_cleanup.js
@@ -72,15 +72,23 @@ function Pzp_CleanUp(){
             PzpObject.messageHandler.removeRoute(_id, PzpObject.getSessionId());
             if(PzpObject.getConnectedPzp(_id)){
                 logger.log ("pzp - " + _id + " details removed");
-                if (PzpObject.getConnectedPzp().length <= 1) PzpObject.setConnectState("Pzp", false);
+                if (PzpObject.getConnectedPzp().length <= 1) {
+                    PzpObject.setConnectState("Pzp", false);
+                    PzpObject.setState("Pzp", "not connected");
+                    PzpObject.setPzhConnectedDevices("pzp", []);
+                }
                 PzpObject.deleteConnectedDevice(_id);
                 return;
             }
             if (PzpObject.getConnectedPzh(_id)) {
                 logger.log ("pzh - " + _id + " details removed");
                 PzpObject.setConnectState("Pzh", false);
+                PzpObject.setState("Pzh", "not connected");
+                PzpObject.setPzhConnectedDevices("pzh", []);
                 PzpObject.deleteConnectedDevice(_id);
             }
+            PzpObject.registerBrowser();
+
             if (PzpObject.getConnectedPzh().length === 0) {
                 startSyncTimer();
             }

--- a/lib/pzp_connectPzh.js
+++ b/lib/pzp_connectPzh.js
@@ -21,18 +21,26 @@
  */
 var PzpConnectHub = function () {
     "use strict";
-    var PzpCommon       = require("./pzp.js");
+    var PzpCommon = require("./pzp.js");
     var PzpObject = this;
-    var logger = PzpCommon.wUtil.webinosLogging(__filename) || console;
+    var logger    = PzpCommon.wUtil.webinosLogging(__filename) || console;
     var pzpClient;
+    var retryTryOut = 0;
+    var retryTimeOut;
 
     //This function will be called when PZH is disconnected and retries connection
     function retryConnecting () {
         if (PzpObject.getEnrolledStatus()) {
             setTimeout (function () {
                 logger.log ("Retrying to connect back to the PZH ");
+                retryTryOut++;
+                if(retryTryOut == 3){
+                    retryTryOut = 0;
+                } else {
+                    retryTimeOut *= 10;
+                }
                 PzpObject.connectOwnPzh();
-            }, PzpObject.getMetaData("retryConnection"));//increase time limit to suggest when it should retry connecting back to the PZH
+            }, retryTimeOut);//increase time limit to suggest when it should retry connecting back to the PZH
         }
     }
 
@@ -49,7 +57,7 @@ var PzpConnectHub = function () {
                 pzpClient.socket.destroy();
                 clearInterval(id)
             });
-        },PzpObject.getMetaData("retryConnection"));
+        },retryTimeOut);
     }
     /**
      *
@@ -57,6 +65,9 @@ var PzpConnectHub = function () {
      */
     this.connectOwnPzh = function () {
         try {
+            if (!retryTimeOut) {
+                retryTimeOut = PzpObject.getMetaData("retryConnection");
+            }
             logger.log("connection towards pzh "+ PzpObject.getPzhId() +" initiated");
             var socket = PzpCommon.net.createConnection(PzpObject.getWebinosPorts("provider"),  PzpObject.getMetaData("serverName")); //Check if we are online..
             socket.setTimeout(10);

--- a/lib/pzp_connectPzh.js
+++ b/lib/pzp_connectPzh.js
@@ -36,6 +36,8 @@ var PzpConnectHub = function () {
                 retryTryOut++;
                 if(retryTryOut == 3){
                     retryTryOut = 0;
+                     // Reset timer
+                    retryTimeOut = PzpObject.getMetaData("retryConnection");
                 } else {
                     retryTimeOut *= 10;
                 }

--- a/lib/pzp_id.js
+++ b/lib/pzp_id.js
@@ -22,21 +22,17 @@ var PzpID = function () {
                 friendlyName = "Webinos Device";// Add manually
             }
         }
-        if (PzpObject.getEnrolledStatus()){
-            friendlyName = PzpObject.getFriendlyName(PzpObject.getPzhId())+ " " + friendlyName;
-        }
         return friendlyName;
     };
 
     /**
      * Sets webinos pzp sessionId
      */
-    this.setSessionId = function () {
-        var sessionId = PzpObject.getMetaData("webinosName");
+    this.setSessionId = function (pzpState) {
+        pzpState.sessionId = PzpObject.getMetaData("webinosName");
         if (PzpObject.getEnrolledStatus()) {
-            sessionId = PzpObject.getPzhId()+ "/" +sessionId;
+            pzpState.sessionId = PzpObject.getPzhId()+ "/" +pzpState.sessionId;
         }
-        return sessionId;
     };
     /**
      * sets webinos application id

--- a/lib/pzp_id.js
+++ b/lib/pzp_id.js
@@ -51,7 +51,7 @@ var PzpID = function () {
                 appId = 'IID' + webAppName.split('/')[2];
             }
             // BID: BrowserID, related to not installed applications
-            else if (webAppOrigin.indexOf('http://') == 0 || webAppOrigin.indexOf('https://') == 0) {
+            else if ( webAppOrigin && (webAppOrigin.indexOf('http://') == 0 || webAppOrigin.indexOf('https://') == 0)) {
                 appId = 'BID' + require("crypto").createHash("md5").update(webAppName).digest("hex");
             }
         }

--- a/lib/pzp_id.js
+++ b/lib/pzp_id.js
@@ -4,7 +4,7 @@ var PzpID = function () {
      * Changes friendly name of the PZP
      * @param {String} friendlyName_ - PZP friendly name intended to be changed
      */
-    this.setFriendlyName = function(friendlyName_) {
+    this.setDefaultFriendlyName = function(friendlyName_) {
         var friendlyName;
         if(friendlyName_) {
             friendlyName = friendlyName_;

--- a/lib/pzp_peerDiscovery.js
+++ b/lib/pzp_peerDiscovery.js
@@ -16,16 +16,15 @@
  * Copyright 2011 Ziran Sun, Samsung Electronics (UK) Ltd
  *******************************************************************************/
 
-var PzpSIB = require("./pzp_SIB_auth.js");
 var PzpPeerDiscovery = function(){
-    PzpSIB.call(this);
     var PzpCommon = require("./pzp.js");
-    this.discoveredPzp=[], // Store Discovered PZP details
+    this.discoveredPzp=[]; // Store Discovered PZP details
     this.networkAddr = "";
     this.connectingPeerAddr = "";
     var logger  = PzpCommon.wUtil.webinosLogging(__filename) || console;
-    var localConnectionManager = require("../../manager/localconnection_manager/lib/localconnectionmanager.js");
+    var localConnectionManager = require("webinos-localConnection");
     this.localConnectionManager = new localConnectionManager.localconnectionManager();
+    var self = this;
 
   /**
    * Advertise PZP with service type "pzp". 
@@ -35,7 +34,7 @@ var PzpPeerDiscovery = function(){
   this.advertPzp = function(discoveryMethod, port) {
     if(!port) port = 4321;
     this.localConnectionManager.advertPeers('pzp', discoveryMethod, port);
-  };  
+  };
 
   /**
    * Find and connect other PZP Peers.   
@@ -47,35 +46,26 @@ var PzpPeerDiscovery = function(){
    */
   this.findPzp = function(parent, discoveryMethod, tlsServerPort, options, callback){
     this.localConnectionManager.findPeers('pzp', discoveryMethod, tlsServerPort, options, function(msg){
-      _parent.pzp_state.discoveredPzp[msg.name] = msg;
-      logger.log("parent.pzp_state.discoveredPzp[" + msg.name + "]");
+      self.discoveredPzp[msg.name] = msg;
       logger.log(msg);
        
       //Filter out self
-      logger.log("own session id: "  + parent.pzp_state.sessionId);
-      var pzpname = msg.name + "_Pzp";
+      logger.log("own session id: "  + parent.getSessionId());
+      var pzpname = msg.name;
       logger.log("pzpname: " + pzpname);
       //TODO: Should also check PZH ID
            
-      if(parent.pzp_state.sessionId.indexOf(pzpname) != -1)
-      {
-        logger.log(parent.getSessionId());
-        parent.pzp_state.networkAddr = msg.address;  //store  own network address for later use
-        logger.log("own address: " + parent.pzp_state.networkAddr);
-      }
-      else
-      {
+      if(parent.getMetaData("webinosName") === pzpname) {
+        self.networkAddr = msg.address;  //store  own network address for later use
+        logger.log("own address: " + self.networkAddr);
+      }else      {
         //filter out already connected msg
-        if (parent.pzp_state.connectedPzp.hasOwnProperty(msg.address) && 
-        self.pzp_state.connectedPzp[msg.address].state === self.states[2])
-          msg.connected = true; 
-        else
-          msg.connected = false; 
+        msg.connected = parent.getConnectedPzp(msg.address);
+
         callback(msg);
       }
     } );
   }; 
   
 };
-require("util").inherits(PzpPeerDiscovery, PzpSIB);
 module.exports = PzpPeerDiscovery;

--- a/lib/pzp_receiveMessage.js
+++ b/lib/pzp_receiveMessage.js
@@ -28,7 +28,8 @@ var PzpReceiveMessage = function () {
             "payload":{
               "status":"csrFromPzp",
               "csr":PzpObject.getCertificateToBeSignedByPzh(),
-              "friendlyName": PzpObject.getFriendlyName()
+              "friendlyName": PzpObject.getFriendlyName(),
+              "deviceType": PzpObject.getMetaData("deviceType")
             }
         }));
     }
@@ -43,14 +44,12 @@ var PzpReceiveMessage = function () {
     }
 
     function changePzpCertificate(msg, connection) {
-        if (expectedPzhAddress === (msg.from && msg.from.split("_") && msg.from.split("_")[0])) {
-            // Re-Generate Master CSR and send it to PZH..
-            PzpObject.setDeviceName(msg.payload.message);
-            PzpObject.createPzpCertificates(); // New PZP ID
-            PzpObject.setSessionId();
-            PzpObject.setupMessage_RPCHandler();
-            beginPzpEnrollment(connection, msg);
-        }
+        // Re-Generate Master CSR and send it to PZH..
+        PzpObject.setDeviceName(msg.payload.message);
+        PzpObject.createPzpCertificates(); // New PZP ID
+        PzpObject.startOtherManagers();
+        beginPzpEnrollment(msg, connection);
+
     }
 
     function gatherTestPageLinks(msg) {
@@ -84,11 +83,12 @@ var PzpReceiveMessage = function () {
         expectedPzhAddress = "https://" + msg.payload.message;
     }
 
-    function connectedDevices(receivedMsg){
-       /* console.log(receivedMsg.payload.message.connectedPzh);
-        console.log(receivedMsg.payload.message.connectedPzp);*/
+    function setDeviceType(msg) {
+        PzpObject.setDeviceType(msg);
     }
-
+    function error(msg){
+        PzpObject.prepMsg(msg.to,"error", msg.payload.message);
+    }
 
     var  methods= {
         "registerBrowser"      :PzpObject.registerBrowser,
@@ -100,6 +100,7 @@ var PzpReceiveMessage = function () {
         "configData"           :getConfigData,
         "logs"                 :getWebinosLog,
         "setPzhProviderAddress":setPzhAddress,
+        "setDeviceType"        :setDeviceType,
         "foundServices"        :PzpObject.getServiceListener,
         "listUnregServices"    :PzpObject.listUnRegServices,
         "registerService"      :PzpObject.registerService,
@@ -107,10 +108,9 @@ var PzpReceiveMessage = function () {
         "syncHash"             :PzpObject.synchronization_compareHash,
         "syncCompare"          :PzpObject.synchronization_findDifference, // PZH Sends this on receipt of syncHash
         "syncUpdate"           :PzpObject.synchronization_update,
-        "changeFriendlyName"   :PzpObject.changeFriendlyName,
-        "connectedDevices"     :connectedDevices
+        "setFriendlyName"      :PzpObject.setFriendlyName,
+        "error"                :error
     };
-
 
     this.wsMessage = function (connection, origin, utf8Data) {
         //schema validation
@@ -156,7 +156,8 @@ var PzpReceiveMessage = function () {
         return msg.payload.status === "setPzhProviderAddress" || // it's an initial message which can come from any origin
             (isSameOriginString(origin, expectedAddress) &&      // OR it's from the origin we expected
                 (msg.payload.status === "enrolRequestCSR" ||     //   and it's an enrolment request
-                    msg.payload.status === "signedCertByPzh"));  //   or it's a set of signed certificates.
+                    msg.payload.status === "signedCertByPzh" ||
+                    msg.payload.status === "pzpId_Update" ));  //   or it's a set of signed certificates.
     }
 
     function handleProcessedMessage(validMsgObj, origin, conn) {
@@ -173,7 +174,7 @@ var PzpReceiveMessage = function () {
                 if(methods[validMsgObj.payload.status]){
                     methods[validMsgObj.payload.status].apply(PzpObject,[validMsgObj, conn]);
                 } else {
-                    logger.error("Invalid message type - message discarded");
+                    logger.error("Invalid message type -"+validMsgObj.payload.status+" message discarded");
                 }
             } else {
                 PzpObject.messageHandler.onMessageReceived(validMsgObj, validMsgObj.to);

--- a/lib/pzp_receiveMessage.js
+++ b/lib/pzp_receiveMessage.js
@@ -89,6 +89,9 @@ var PzpReceiveMessage = function () {
     function error(msg){
         PzpObject.prepMsg(msg.to,"error", msg.payload.message);
     }
+    function setFriendlyName(msg){
+        PzpObject.setFriendlyName(msg);
+    }
 
     var  methods= {
         "registerBrowser"      :PzpObject.registerBrowser,
@@ -108,7 +111,7 @@ var PzpReceiveMessage = function () {
         "syncHash"             :PzpObject.synchronization_compareHash,
         "syncCompare"          :PzpObject.synchronization_findDifference, // PZH Sends this on receipt of syncHash
         "syncUpdate"           :PzpObject.synchronization_update,
-        "setFriendlyName"      :PzpObject.setFriendlyName,
+        "setFriendlyName"      :setFriendlyName,
         "error"                :error
     };
 

--- a/lib/pzp_serviceHandler.js
+++ b/lib/pzp_serviceHandler.js
@@ -165,8 +165,7 @@ var PzpServiceHandler = function () {
                       , hostname : PzpObject.getPzpHost()
                     }
                 }, PzpObject.moduleHttpHandlers); // load specified modules
-            
-            configData.params = params;
+            var configData={"params":params}; 
             PzpCommon.fs.writeFileSync(PzpCommon.path.resolve(foundService.path, "config.json"), JSON.stringify(configData, null, "  "));
             return true;
         }

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -351,7 +351,12 @@ function Pzp(inputConfig) {
             PzpObject.updateWebinosPort("provider", payload.serverPort);
             
             if (!config.trustedList.pzh.hasOwnProperty (config.metaData.pzhId)) {
-                config.trustedList.pzh[config.metaData.pzhId] = {friendlyName: payload.friendlyName};
+                config.trustedList.pzh[config.metaData.pzhId] = {
+                    "email": "", "photoUrl": "",
+                    "friendlyName": payload.friendlyName,
+                    "nickname": "",
+                    "authenticator": "",
+                    "identifier": ""};
             }
             pzpState.enrolled = true;
             PzpObject.setSessionId(pzpState); // IMP during enrollment sessionId changes..

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  *  Code contributed to the webinos project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -481,6 +481,7 @@ require("util").inherits(Pzp, PzpReceiveMessage);
 Pzp.prototype.__proto__ = require("events").EventEmitter.prototype;
 
 var PzpAPI = exports;
+PzpAPI.otherPzpInstance = {};
 PzpAPI.setInputConfig = function(inputConfig) {
     PzpAPI.inputConfig = inputConfig;
 };
@@ -490,8 +491,9 @@ PzpAPI.getInstance = function() {
         return null;
     }
     if (PzpAPI.inputConfig.forcedDeviceName){
-        PzpAPI.otherPzpInstance = new Pzp(PzpAPI.inputConfig);
-        return PzpAPI.otherPzpInstance;
+        if (!PzpAPI.otherPzpInstance[PzpAPI.inputConfig.forcedDeviceName])
+            PzpAPI.otherPzpInstance[PzpAPI.inputConfig.forcedDeviceName] = new Pzp(PzpAPI.inputConfig);
+        return PzpAPI.otherPzpInstance[PzpAPI.inputConfig.forcedDeviceName];
     }
     if (!PzpAPI.pzpInstance) {
         PzpAPI.pzpInstance = new Pzp(PzpAPI.inputConfig);

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -119,6 +119,7 @@ function Pzp(inputConfig) {
     };
     this.updateCRL         = function(value) {config.cert.crl.value = value; config.storeDetails("crl", config.cert.crl);};
     this.getSignedCertificateObj = function(){ return (config.cert.internal.signedCert || "{}"                  ); };
+    this.getSignedCert = function(id){ return (config.cert.internal.signedCert[id] || config.cert.internal.signedCert); };
     this.updateExternalCertificates = function(value) {
         config.cert.external = value;
         config.storeDetails(PzpCommon.path.join("certificates","external"), "certificates",config.cert.external);
@@ -235,6 +236,16 @@ function Pzp(inputConfig) {
         }
     };
 
+
+    this.signCertificate = function(pzpId, csr, friendlyName) {
+        if(config.cert.internal.signedCert[pzpId] = config.cert.generateSignedCertificate(csr)) {
+            config.storeDetails(require("path").join("certificates", "internal"), "certificates", config.cert.internal);
+            if (!config.trustedList.pzp.hasOwnProperty(id)) {// update configuration with signed certificate details ..
+                config.trustedList.pzp[pzpId] = {"friendlyName": PzpObject.getFriendlyName(PzpObject.getPzhId())+ " " + friendlyName};
+                config.storeDetails("trustedList", config.trustedList);
+            }
+        }
+    };
     /**
      * EnrollPZP stores signed certificate information from the PZH and then triggers connectHub function
      * @param from - Contains PZH Id

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -55,24 +55,59 @@ function Pzp(inputConfig) {
         connectedDevicesToPzh: {pzp:[], pzh: [] } }; //Stores information about device connected to PZH but not to PZP.
 
     // PZP state query by other PZP components
-    this.getPzhId               = function()   { return config.metaData.pzhId; };
-    this.getSessionId           = function()   { return pzpState.sessionId; };
-    this.getEnrolledStatus      = function()   { return pzpState.enrolled;   };
-    this.getState               = function(id) { return (id? pzpState.state[id] : pzpState.state);  };
-    this.setState               = function(type, status) { pzpState.state[type] = status; };
-    this.getConnectedPzp        = function(id) { return (id? pzpState.connectedPzp[id]: Object.keys(pzpState.connectedPzp));  };
-    this.getConnectedPzh        = function(id) { return (id? pzpState.connectedPzh[id]: Object.keys(pzpState.connectedPzh));  };
-    this.getPzhConnectedDevices = function(id) { return (Object.keys(pzpState.connectedDevicesToPzh[id])); };
-    this.setPzhConnectedDevices = function(type, value) { pzpState.connectedDevicesToPzh[type] = value; };
+    this.getPzhId               = function()   {
+        return config.metaData.pzhId;
+    };
+    this.getSessionId           = function()   {
+        return pzpState.sessionId;
+    };
+    this.getEnrolledStatus      = function()   {
+        return pzpState.enrolled;
+    };
+    this.getState               = function(id) {
+        return (id? pzpState.state[id] : pzpState.state);  }
+    ;
+    this.setState               = function(type, status) {
+        pzpState.state[type] = status;
+    };
+    this.getConnectedPzp        = function(id) {
+        return (id? pzpState.connectedPzp[id]: Object.keys(pzpState.connectedPzp));
+    };
+    this.getConnectedPzh        = function(id) {
+        return (id? pzpState.connectedPzh[id]: Object.keys(pzpState.connectedPzh));
+    };
+    this.getPzhConnectedDevices = function(id) {
+        return (Object.keys(pzpState.connectedDevicesToPzh[id]));
+    };
+    this.setPzhConnectedDevices = function(type, value) {
+        pzpState.connectedDevicesToPzh[type] = value;
+    };
 
     // PZP metaData information retrieved by other PZP components
-    this.getTrustedList         = function(id) { return (id==="pzh"? Object.keys(config.trustedList.pzh): (id=== "pzp"?Object.keys(config.trustedList.pzp):config.trustedList)); };
-    this.getFriendlyName        = function(id) { return (id ? ((config.trustedList.pzh[id] && config.trustedList.pzh[id].friendlyName) || (config.trustedList.pzp[id] && config.trustedList.pzp[id].friendlyName)): config.metaData.friendlyName); };
-    this.getMetaData            = function(id) { return (id ? config.metaData[id]: config.metaData); };
-    this.getFileList            = function()   { return config.fileList; };
-    this.getPzpHost             = function()   { return config.pzpHost };
+    this.getTrustedList         = function(id) {
+        return (id==="pzh"? config.trustedList.pzh: (id=== "pzp" ? config.trustedList.pzp :config.trustedList));
+    };
+    this.getFriendlyName        = function(id) {
+        if (!pzpState.enrolled) {
+            return config.metaData.friendlyName;
+        } else {
+            if (!id) id = pzpState.sessionId;
+            return ((config.trustedList.pzh[id] && config.trustedList.pzh[id].friendlyName) ||
+                (config.trustedList.pzp[id] && config.trustedList.pzp[id].friendlyName));
+        }
+    };
+    this.getMetaData            = function(id) {
+        return (id ? config.metaData[id]: config.metaData);
+    };
+    this.getFileList            = function()   {
+        return config.fileList; };
+    this.getPzpHost             = function()   {
+        return config.pzpHost
+    };
     // Other configuration data
-    this.getWebinosPorts        = function(id) { return (id? config.userPref.ports[id]: config.userPref.ports);};
+    this.getWebinosPorts        = function(id) {
+        return (id? config.userPref.ports[id]: config.userPref.ports);
+    };
     this.getServiceCache        = function()   {
         function contains(localArr, lname) {
             for (var i = 0 ; i < localArr.length; i = i + 1) {
@@ -88,21 +123,34 @@ function Pzp(inputConfig) {
         remoteCache.sort(function(a,b) {return ((a.id)> ( b.id) ? 1 : ((b.id) > (a.id)) ? -1 : 0);} );
         return remoteCache;
     };
-    this.getCertificate         = function(id) { return config.cert.internal[id].cert };
-    this.getUserData            = function(id) { return (id? config.cert.userData[id]: config.cert.userData); };
-    this.getCRL                 = function()   { return config.cert.crl.value; };
-    this.getCertificateToBeSignedByPzh = function()   { return config.cert.internal.master.csr; };
+    this.getCertificate         = function(id) {
+        return config.cert.internal[id].cert
+    };
+    this.getUserData            = function(id) {
+        return (id? config.cert.userData[id]: config.cert.userData);
+    };
+    this.getCRL                 = function()   {
+        return config.cert.crl.value;
+    };
+    this.getCertificateToBeSignedByPzh = function()   {
+        return config.cert.internal.master.csr;
+    };
     this.getExternalCertificates       = function(id) {
       if(config.cert.external) {
         return (id?config.cert.external[id]: Object.keys(config.cert.external));
       }
     };
-    this.getExternalCertificateObj     = function() { return config.cert.external; };
+    this.getExternalCertificateObj     = function() {
+        return config.cert.external;
+    };
     // Checks if component is currently connected to device directly or to the PZH
-    this.checkConnectedPzh = function(from) { return (pzpState.connectedPzh.hasOwnProperty(from) || pzpState.connectedDevicesToPzh.pzh.hasOwnProperty(from)); };
-    this.checkConnectedPzp = function(from) { return (pzpState.connectedPzp.hasOwnProperty(from) || pzpState.connectedDevicesToPzh.pzp.hasOwnProperty(from)); };
+    this.checkConnectedPzh = function(from) {
+        return (pzpState.connectedPzh.hasOwnProperty(from) || pzpState.connectedDevicesToPzh.pzh.hasOwnProperty(from));
+    };
+    this.checkConnectedPzp = function(from) {
+        return (pzpState.connectedPzp.hasOwnProperty(from) || pzpState.connectedDevicesToPzh.pzp.hasOwnProperty(from));
+    };
     // Change device name, this happens only when the name already exists in the zone, PZH instructs this name change.
-    this.setDeviceName     = function(name) { config.metaData.webinosName = name; };
     this.updateTrustedList = function(value) {
         config.trustedList = value;
         config.storeDetails("trustedList", config.trustedList);
@@ -117,16 +165,36 @@ function Pzp(inputConfig) {
             pm.policyEvent.emit("updateFriends");
         }
     };
-    this.updateCRL         = function(value) {config.cert.crl.value = value; config.storeDetails("crl", config.cert.crl);};
-    this.getSignedCertificateObj = function(){ return (config.cert.internal.signedCert || "{}"                  ); };
-    this.getSignedCert = function(id){ return (config.cert.internal.signedCert[id] || config.cert.internal.signedCert); };
+    this.setDeviceName     = function(name) {
+        config.metaData.webinosName = name;
+    };
+    this.setDeviceType = function(msg) {
+        config.metaData.deviceType = msg.payload.message;
+        config.storeDetails("metaData",config.metaData);
+    };
+    this.updateCRL         = function(value) {
+        config.cert.crl.value = value; config.storeDetails("crl", config.cert.crl);
+    };
+    this.getSignedCertificateObj = function(){
+        return (config.cert.internal.signedCert || "{}"                  );
+    };
+    this.getSignedCert = function(id){
+        return (config.cert.internal.signedCert[id] || config.cert.internal.signedCert);
+    };
     this.updateExternalCertificates = function(value) {
         config.cert.external = value;
         config.storeDetails(PzpCommon.path.join("certificates","external"), "certificates",config.cert.external);
     };
-    this.updateSignedCertificates = function(value) {config.cert.internal.signedCert = value; config.storeDetails(PzpCommon.path.join("certificates","internal"), "signedCertificates",config.cert.internal.signedCert);};
-    this.getConnectedDevices = function() { return pzpState.connectedDevicesToPzh; };
-    this.updateConnectedDevices = function(details){pzpState.connectedDevicesToPzh = details; };
+    this.updateSignedCertificates = function(value) {
+        config.cert.internal.signedCert = value;
+        config.storeDetails(PzpCommon.path.join("certificates","internal"), "signedCertificates",config.cert.internal.signedCert);
+    };
+    this.getConnectedDevices = function() {
+        return pzpState.connectedDevicesToPzh;
+    };
+    this.updateConnectedDevices = function(details){
+        pzpState.connectedDevicesToPzh = details;
+    };
     this.updateStoreServiceCache = function(serviceCache) {
         config.serviceCache = serviceCache;
         var extServ = [];
@@ -139,7 +207,9 @@ function Pzp(inputConfig) {
         PzpObject.addRemoteServices(extServ);
     };
 
-    this.updateWebinosPort = function(key, value) {config.userPref.ports[key] = value; config.storeDetails("userData", "userPref", config.userPref) };
+    this.updateWebinosPort = function(key, value) {
+        config.userPref.ports[key] = value;
+    };
     this.checkTrustedList = function(from) {
         var list = from.split("/"), fromTrustedPzh, fromTrustedPzp;
         if(list.length === 3) { fromTrustedPzp = list[0]+ "/"+ list[1]; fromTrustedPzh = list[0];}   // From App
@@ -278,18 +348,20 @@ function Pzp(inputConfig) {
                 config.metaData.serverName = config.metaData.serverName.split (":")[0];
             }
 
-            config.userPref.ports.provider   = payload.serverPort;
-
+            PzpObject.updateWebinosPort("provider", payload.serverPort);
+            
             if (!config.trustedList.pzh.hasOwnProperty (config.metaData.pzhId)) {
-                config.trustedList.pzh[config.metaData.pzhId] = {friendlyName: payload.friendlyName, remoteAddress: config.metaData.serverName };
+                config.trustedList.pzh[config.metaData.pzhId] = {friendlyName: payload.friendlyName};
             }
             pzpState.enrolled = true;
-            pzpState.sessionId = PzpObject.setSessionId(); // IMP during enrollment sessionId changes..
-            config.metaData.friendlyName = PzpObject.setFriendlyName(payload.pzpFriendlyName)
+            PzpObject.setSessionId(pzpState); // IMP during enrollment sessionId changes..
+            config.trustedList.pzp[pzpState.sessionId]= {friendlyName: payload.pzpFriendlyName,
+                                                         deviceType: config.metaData.deviceType,
+                                                         pzhId: config.metaData.pzhId
+                                                        };
             config.serviceCache = [];
-            PzpObject.startServer();
+            PzpObject.startTLSServer();
             config.storeDetails("userData", "serviceCache", config.serviceCache);
-            config.storeDetails("userData", "userPref", config.userPref);
             config.storeDetails("metaData", config.metaData);
             config.storeDetails("crl", config.crl);
             config.storeDetails("trustedList", config.trustedList);
@@ -341,10 +413,8 @@ function Pzp(inputConfig) {
             config.metaData.retryConnection = PzpDefaultConfig.retryConnection;
             config.metaData.friendlyName = PzpObject.setFriendlyName(inputConfig.friendlyName || PzpDefaultConfig.friendlyName);
             config.storeDetails("metaData", config.metaData);
-            config.storeDetails("userData", "userPref", config.userPref);
             if (PzpObject.createPzpCertificates()) {
                 logger.log("created default set of PZP certificates");
-                config.storeDetails("userData", "userDetails", config.cert.userData);
             } // If PZP certificate will fail, it will generate error on its own
         }
     }
@@ -354,7 +424,6 @@ function Pzp(inputConfig) {
      * Starting PZP means starting web socket server
      */
     PzpObject.initializePzp = function() {
-
         try {
             PzpCommon.wUtil.webinosHostname.getHostName(inputConfig.pzpHost, function (pzpHost) {
                 config = new PzpCommon.wUtil.webinosConfiguration("Pzp", inputConfig);// sets configuration
@@ -362,16 +431,18 @@ function Pzp(inputConfig) {
                 config.cert = new PzpCommon.wCertificate(config.metaData);
                 if(!config.loadWebinosConfiguration()){
                    virginPzpInitialization();
+                }else {
+                    config.userPref.ports = require("../config.json").ports;
                 }
                 config.loadCertificates(config.cert);
                 if(config.metaData.pzhId) pzpState.enrolled = true;
-                pzpState.sessionId = PzpObject.setSessionId();
+                PzpObject.setSessionId(pzpState);
                 logger.addId(pzpState.sessionId);
                 PzpObject.startWebSocketServer();
                 PzpObject.startOtherManagers();
                 if (pzpState.enrolled) {
                     PzpObject.connectOwnPzh();
-                    PzpObject.startServer();
+                    PzpObject.startTLSServer();
                 }
             });
         } catch (err) {

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -217,7 +217,16 @@ function Pzp(inputConfig) {
         if(list.length === 1) { fromTrustedPzh = list[0];} // From trusted PZH
         return (config && config.trustedList && (config.trustedList.pzh.hasOwnProperty(fromTrustedPzh) || config.trustedList.pzp.hasOwnProperty(fromTrustedPzp)));
     };
-
+    
+    this.setFriendlyName = function(msg) {
+       if (pzpState.enrolled && PzpObject.checkTrustedList(pzpState.sessionId)) {
+          config.trustedList.pzp[pzpState.sessionId].friendlyName = msg.payload.message;
+          config.storeDetails("trustedList", config.trustedList);
+       } else {
+         config.metaData.friendlyName = msg.payload.message;
+         config.storeDetails("metaData", config.metaData);
+       }
+    };
     this.deleteConnectedDevice = function(_id){
         var socket = pzpState.connectedPzh[_id] || pzpState.connectedPzp[_id];
         socket.socket.end();
@@ -408,7 +417,7 @@ function Pzp(inputConfig) {
         } catch(err){
             PzpObject.emit("FUNC_ERROR", "PZP create certificate failed");
         }
-    };
+    };    
 
     function virginPzpInitialization(){
         if(config.createDefaultDirectories()) {
@@ -416,7 +425,7 @@ function Pzp(inputConfig) {
             config.userPref.ports = PzpDefaultConfig.ports;
             config.metaData.webinos_version = PzpDefaultConfig.webinos_version;
             config.metaData.retryConnection = PzpDefaultConfig.retryConnection;
-            config.metaData.friendlyName = PzpObject.setFriendlyName(inputConfig.friendlyName || PzpDefaultConfig.friendlyName);
+            config.metaData.friendlyName = PzpObject.setDefaultFriendlyName(inputConfig.friendlyName || PzpDefaultConfig.friendlyName);
             config.storeDetails("metaData", config.metaData);
             if (PzpObject.createPzpCertificates()) {
                 logger.log("created default set of PZP certificates");

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -59,9 +59,11 @@ function Pzp(inputConfig) {
     this.getSessionId           = function()   { return pzpState.sessionId; };
     this.getEnrolledStatus      = function()   { return pzpState.enrolled;   };
     this.getState               = function(id) { return (id? pzpState.state[id] : pzpState.state);  };
+    this.setState               = function(type, status) { pzpState.state[type] = status; };
     this.getConnectedPzp        = function(id) { return (id? pzpState.connectedPzp[id]: Object.keys(pzpState.connectedPzp));  };
     this.getConnectedPzh        = function(id) { return (id? pzpState.connectedPzh[id]: Object.keys(pzpState.connectedPzh));  };
     this.getPzhConnectedDevices = function(id) { return (Object.keys(pzpState.connectedDevicesToPzh[id])); };
+    this.setPzhConnectedDevices = function(type, value) { pzpState.connectedDevicesToPzh[type] = value; };
 
     // PZP metaData information retrieved by other PZP components
     this.getTrustedList         = function(id) { return (id==="pzh"? Object.keys(config.trustedList.pzh): (id=== "pzp"?Object.keys(config.trustedList.pzp):config.trustedList)); };
@@ -230,8 +232,6 @@ function Pzp(inputConfig) {
         if (type) PzpObject.emit(type.toUpperCase()+"_CONNECT_FAILED");
         if (conn.authorizationError === 'CERT_NOT_YET_VALID') {
             throw "possible clock difference between PZH and your PZP, try updating time and try again";
-        } else {
-            if(conn.authorizationError) throw conn.authorizationError;
         }
     };
 
@@ -276,6 +276,7 @@ function Pzp(inputConfig) {
             pzpState.sessionId = PzpObject.setSessionId(); // IMP during enrollment sessionId changes..
             config.metaData.friendlyName = PzpObject.setFriendlyName(payload.pzpFriendlyName)
             config.serviceCache = [];
+            PzpObject.startServer();
             config.storeDetails("userData", "serviceCache", config.serviceCache);
             config.storeDetails("userData", "userPref", config.userPref);
             config.storeDetails("metaData", config.metaData);

--- a/lib/pzp_syncHandler.js
+++ b/lib/pzp_syncHandler.js
@@ -22,7 +22,7 @@ var PzpSync = function () {
     var PzpCommon = require("./pzp.js");
     var logger = PzpCommon.wUtil.webinosLogging(__filename) || console;
     var syncInstance;
-
+    var storeLastDiffHash= {};
     function prepareSyncList() {
         var list = {};
         if (syncInstance) {
@@ -64,6 +64,7 @@ var PzpSync = function () {
             if (syncInstance &&  receivedMsg.payload.message) {
                 var ownList = prepareSyncList();
                 var list_ = syncInstance.compareObjectHash(ownList, receivedMsg.payload.message);
+                storeLastDiffHash = receivedMsg.payload.message;
                 if (list_.length !== 0) {
                     PzpObject.prepMsg(receivedMsg.from, "syncCompare", list_);
                 } else {
@@ -79,6 +80,7 @@ var PzpSync = function () {
     PzpObject.synchronization_findDifference = function(receivedMsg) {
         if (syncInstance && receivedMsg) {
             var list = prepareSyncList();
+            storeLastDiffHash = receivedMsg.payload.message;
             var msg = syncInstance.sendObjectContents(list, receivedMsg.payload.message);
             if (Object.keys(msg).length !== 0) {
                 PzpObject.prepMsg (receivedMsg.from, "syncUpdate", msg);
@@ -91,12 +93,12 @@ var PzpSync = function () {
         try {
             if(syncInstance) {
                 if (receivedMsg && receivedMsg.payload && receivedMsg.payload.message){
-                    receivedMsg = receivedMsg.payload.message;
                     id = receivedMsg.from;
+                    receivedMsg = receivedMsg.payload.message;
                 }
                 var list = prepareSyncList();
                 if (receivedMsg !== {}) {
-                    syncInstance.applyObjectContents(list, receivedMsg);
+                    syncInstance.applyObjectContents(list, receivedMsg); // After this step list is combined copy of local and remote copy
                     for (var key in list){
                         if (list.hasOwnProperty(key)){
                             if (key === "trustedList"&& JSON.stringify(PzpObject.getTrustedList()) !== JSON.stringify(list[key])) {
@@ -131,6 +133,21 @@ var PzpSync = function () {
                         }
                     }
                     logger.log ("Files Synchronised with the PZH");
+                }
+                // At this moment everything is synced, send sync to PZH. If there is anything that;s not synced could be synced with PZH
+                var inNeedOfSync = 0;
+                var newList={};
+                var checkChanges =  syncInstance.getObjectHash(prepareSyncList());
+                for ( key in checkChanges ){
+                    if (checkChanges.hasOwnProperty(key) && key != "connectedDevices" && checkChanges[key]!==storeLastDiffHash[key]) {
+                        newList[key] = list[key];
+                        inNeedOfSync = 1;
+                    }
+                }
+                storeLastDiffHash={};
+                if (inNeedOfSync == 1){
+                   logger.log("PZP is in need of sync -- ");
+                   PzpObject.prepMsg (id, "syncUpdate", newList);
                 }
                 PzpObject.decideToKeepConnectionAliveOrClose(id);
             }

--- a/lib/pzp_tlsServer.js
+++ b/lib/pzp_tlsServer.js
@@ -31,7 +31,7 @@ var PzpServer = function () {
     /**
      * Starts PZP TLS server
      */
-    this.startServer = function() {
+    this.startTLSServer = function() {
         if (!tlsServer) {
             var options = PzpObject.setConnectionParameters();
             options.servername = "0.0.0.0";

--- a/lib/pzp_tlsServer.js
+++ b/lib/pzp_tlsServer.js
@@ -35,6 +35,7 @@ var PzpServer = function () {
         if (!tlsServer) {
             var options = PzpObject.setConnectionParameters();
             options.servername = "0.0.0.0";
+            options.rejectUnauthorized = false;
             var otherPzpCert = PzpObject.getSignedCertificateObj();
             options.ca=[];
             options.ca.push(PzpObject.getCertificate("pzh"));
@@ -45,6 +46,10 @@ var PzpServer = function () {
                 if (conn.authorized) {
                     PzpObject.handleAuthorization(conn);
                 } else {
+                    if(conn.authorizationError === "UNABLE_TO_GET_ISSUER_CERT") {
+
+                    }
+
                     PzpObject.unAuthorized(conn, "Pzp");
                 }
 

--- a/lib/pzp_tlsServer.js
+++ b/lib/pzp_tlsServer.js
@@ -47,14 +47,34 @@ var PzpServer = function () {
                     PzpObject.handleAuthorization(conn);
                 } else {
                     if(conn.authorizationError === "UNABLE_TO_GET_ISSUER_CERT") {
+                        // Device issuer certificate not received
+                        // Socket will be open to receive message
 
+                    } else {
+                        PzpObject.unAuthorized(conn, "Pzp");
                     }
-
-                    PzpObject.unAuthorized(conn, "Pzp");
                 }
 
                 conn.on ("data", function (buffer) {
-                    PzpObject.handleMsg(conn, buffer);
+                    var receivedData = buffer.toString();
+                    var parseData = JSON.parse(receivedData);
+                    if (parseData.payload.type === "microPzpEnrollment") {
+                        var pzpId = PzpObject.getPzhId() +"/"+ parseData.from;
+                        PzpObject.signCertificate(pzpId, parseData.payload.message.csr, parseData.payload.message.friendlyName);
+                        var payload = {
+                            "clientCert"  :PzpObject.getSignedCert(pzpId),
+                            "masterCert"  :PzpObject.getCertificate("master"),
+                            "masterCrl"   :PzpObject.getCRL(),
+                            "friendlyName":PzpObject.getFriendlyName(),
+                            "pzpFriendlyName": PzpObject.getFriendlyName(PzpObject.getPzhId()) + " " +parseData.payload.message.friendlyName
+                        };
+
+                        var msg = {"type":"prop", "from":PzpObject.getSessionId(), "to":pzpId, "payload":{"status":"signedCertByPzp","message":payload}};
+                        conn.write(JSON.stringify(msg));
+                    } else {
+                        PzpObject.handleMsg(conn, buffer);
+                    }
+
                 });
 
                 conn.on ("end", function () {

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -93,11 +93,14 @@ function PzpWebSocketServer(){
     function getConnectedInfo() {
         var list = [],zonePzh, zonePzp, isConnected;
         var pzhId = PzpObject.getPzhId();
-        zonePzh = PzpObject.getTrustedList("pzh");
-        zonePzp = PzpObject.getTrustedList("pzp");
+        zonePzh = Object.keys(PzpObject.getTrustedList("pzh"));
+        zonePzp = Object.keys(PzpObject.getTrustedList("pzp"));
+
         var connectedDevice = PzpObject.getConnectedDevices();
-        if (pzhId && connectedDevice.pzh.indexOf(pzhId) === -1 && PzpObject.getConnectedPzh(pzhId)) connectedDevice.pzh.push(pzhId);
-        console.log(connectedDevice);
+        if (pzhId && connectedDevice.pzh.indexOf(pzhId) === -1 && PzpObject.getConnectedPzh(pzhId)) {
+            connectedDevice.pzh.push(pzhId);
+        }
+        console.log(zonePzh, zonePzp, connectedDevice);
        // Not connected to PZH
         for (var i =0; i < zonePzh.length; i = i + 1) {
             var pzhId = zonePzh[i], pzp=[];
@@ -105,11 +108,20 @@ function PzpWebSocketServer(){
                 if(pzhId === zonePzp[j].split("/")[0]){
                     isConnected = (connectedDevice.pzp.indexOf(zonePzp[j]) === -1) ? false : true;
 
-                    pzp.push({friendlyName: PzpObject.getFriendlyName(zonePzp[j]), id: zonePzp[j], connected:isConnected});
+                    pzp.push({friendlyName: PzpObject.getFriendlyName(zonePzp[j]),
+                      id: zonePzp[j],
+                      deviceType: PzpObject.getTrustedList("pzp") && PzpObject.getTrustedList("pzp")[zonePzp[j]]
+                                  && PzpObject.getTrustedList("pzp")[zonePzp[j]].deviceType,
+                      isConnected:isConnected});
                 }
             }
             isConnected = (connectedDevice.pzh.indexOf(pzhId) === -1) ? false : true;
-            list.push( {id: pzhId, friendlyName: PzpObject.getFriendlyName(pzhId), pzp: pzp, connected: isConnected});
+            list.push( {id: pzhId,
+                friendlyName: PzpObject.getFriendlyName(pzhId),
+                pzp: pzp,
+                photoUrl:PzpObject.getTrustedList("pzh") && PzpObject.getTrustedList("pzh")[pzhId]
+                    && PzpObject.getTrustedList("pzh")[pzhId].photoUrl ,
+                isConnected: isConnected});
         }
 //        if (PzpObject.getEnrolledStatus())
 //            list.push({id: PzpObject.getPzhId(),

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -100,8 +100,7 @@ function PzpWebSocketServer(){
         if (pzhId && connectedDevice.pzh.indexOf(pzhId) === -1 && PzpObject.getConnectedPzh(pzhId)) {
             connectedDevice.pzh.push(pzhId);
         }
-        console.log(zonePzh, zonePzp, connectedDevice);
-       // Not connected to PZH
+	// Not connected to PZH
         for (var i =0; i < zonePzh.length; i = i + 1) {
             var pzhId = zonePzh[i], pzp=[];
             for (var j=0; j < zonePzp.length; j = j +1) {

--- a/lib/pzp_websocket.js
+++ b/lib/pzp_websocket.js
@@ -91,20 +91,25 @@ function PzpWebSocketServer(){
      * @return {Array}
      */
     function getConnectedInfo() {
-        var list = [],zonePzh, zonePzp;
+        var list = [],zonePzh, zonePzp, isConnected;
+        var pzhId = PzpObject.getPzhId();
         zonePzh = PzpObject.getTrustedList("pzh");
         zonePzp = PzpObject.getTrustedList("pzp");
-
+        var connectedDevice = PzpObject.getConnectedDevices();
+        if (pzhId && connectedDevice.pzh.indexOf(pzhId) === -1 && PzpObject.getConnectedPzh(pzhId)) connectedDevice.pzh.push(pzhId);
+        console.log(connectedDevice);
        // Not connected to PZH
         for (var i =0; i < zonePzh.length; i = i + 1) {
             var pzhId = zonePzh[i], pzp=[];
             for (var j=0; j < zonePzp.length; j = j +1) {
                 if(pzhId === zonePzp[j].split("/")[0]){
-                    console.log(zonePzp[i])
-                    pzp.push({friendlyName: PzpObject.getFriendlyName(zonePzp[j]), id: zonePzp[j]});
+                    isConnected = (connectedDevice.pzp.indexOf(zonePzp[j]) === -1) ? false : true;
+
+                    pzp.push({friendlyName: PzpObject.getFriendlyName(zonePzp[j]), id: zonePzp[j], connected:isConnected});
                 }
             }
-            list.push( {id: pzhId, friendlyName: PzpObject.getFriendlyName(pzhId), pzp: pzp });
+            isConnected = (connectedDevice.pzh.indexOf(pzhId) === -1) ? false : true;
+            list.push( {id: pzhId, friendlyName: PzpObject.getFriendlyName(pzhId), pzp: pzp, connected: isConnected});
         }
 //        if (PzpObject.getEnrolledStatus())
 //            list.push({id: PzpObject.getPzhId(),
@@ -160,7 +165,7 @@ function PzpWebSocketServer(){
     };
 
     function sendApplicationItsId(msgType, to) {
-        var msg, payload = { 
+        var msg, payload = {
             "pzhId": PzpObject.getPzhId(),
             "connectedDevices" :getConnectedInfo(),
             "state"        :PzpObject.getState(),

--- a/test/jasmine/pzp.spec.js
+++ b/test/jasmine/pzp.spec.js
@@ -511,7 +511,7 @@ describe("PZH - PZH certificate exchange", function() {
                     if ((i + 1) < numberOfPZH) findServicePzp(i+1);
                     else done();
                 });
-            }, 200); // A delay as connection between PZH take time to exchange services
+            }, 1000); // A delay as connection between PZH take time to exchange services
 
         }
         findServicePzp(1);

--- a/test/jasmine/pzp.spec.js
+++ b/test/jasmine/pzp.spec.js
@@ -196,17 +196,10 @@ describe("PZP default configuration in VIRGIN mode", function(){
 //        expect(serviceCache).toEqual(pzpInstance.getServiceCache());
     });
     it ("Default userData i.e. details that will be used by certificate", function() {
-        var userData = JSON.parse(fs.readFileSync(path.join(webinosPath,"userData","userDetails.json")).toString());
-        expect(userData).not.toBeNull();
         expect(pzpInstance.getUserData()).not.toBeNull();
-        expect(userData).toEqual(pzpInstance.getUserData());
     });
     it ("Ports configuration", function() {
-        var userPref = JSON.parse(fs.readFileSync(path.join(webinosPath,"userData","userPref.json")).toString());
-        expect(userPref).not.toBeNull();
         expect(pzpInstance.getWebinosPorts()).not.toBeNull();
-        expect(JSON.stringify(userPref.ports)).toEqual(JSON.stringify(pzpInstance.getWebinosPorts()));
-        expect(pzp_api.getWebinosPorts()).not.toBeNull(); // Check PZP exposed API are having right value
         expect(pzp_api.getWebinosPorts()).toEqual(pzpInstance.getWebinosPorts());
     });
     it("search particular service configuration data", function(){
@@ -596,4 +589,3 @@ describe("check synchronization with the PZH", function(){
         done();
     },2000);
 });
- 

--- a/web_root/connectPzh.html
+++ b/web_root/connectPzh.html
@@ -8,21 +8,43 @@
   <script type="text/javascript" src="./webinos.js"></script>
   <script type="text/javascript">
     $ (document).ready (function () {
+      function setFriendlyName() {
+        console.log(webinos.session.getPZPId());
+        console.log(webinos.session.getFriendlyName(webinos.session.getPZPId()));
+        document.getElementById("friendlyName").setAttribute("value",
+        webinos.session.getFriendlyName(webinos.session.getPZPId()));
+      }
+      webinos.session.addListener ('registeredBrowser', setFriendlyName);
       $ ("#connectPzh").click (function () {
+        var deviceType = $("#deviceTypeList option:selected").val().trim();
+        if(!deviceType){
+          alert("Please set device type before connecting PZH");
+          return;
+        }
+        var friendlyName = document.getElementById ("friendlyName").value.trim();
+        if(!friendlyName){
+          alert("Please set device friendlyName before connecting PZH");
+          return;
+        }
+        var pzhAddress;
         if (document.getElementById ("own_pzh") && document.getElementById ("own_pzh").value !== "undefined" &&
                 document.getElementById ("own_pzh").value !== "") {
-          value = document.getElementById ("own_pzh").value.trim();
+            pzhAddress = document.getElementById ("own_pzh").value.trim();
         } else {
-          value = $ ("#pzh_list option:selected").val().trim();
+            pzhAddress = $ ("#pzh_list option:selected").val().trim();
         }
-        if (value === "localhost") {
+        if (pzhAddress === "localhost") {
             alert("Please use PZH IP address to connect. Using localhost is not supported");
         } else {
             $ ("#provider").hide ();
-            var options = {type:'prop', payload:{status:'setPzhProviderAddress', message:value}};
+            var options = {type:'prop', payload:{status:'setPzhProviderAddress', message:pzhAddress}};
             webinos.session.message_send (options);
-
-            window.location.href = "https://" + value + "/login?isPzp=true&port=" + webinos.session.getPzpPort ();
+            options = {type:'prop', payload:{status:'setFriendlyName',           message:friendlyName}};
+            webinos.session.message_send (options);
+            options = {type:'prop', payload:{status:'setDeviceType',             message:deviceType}};
+            webinos.session.message_send (options);
+            window.location.href ="https://" + pzhAddress + "/login?isPzp=true&port="+webinos.session.getPzpPort()+
+                                    "&deviceType="+deviceType+"&friendlyName="+friendlyName;
         }
       });
     });
@@ -36,6 +58,21 @@
     <label>Connect your device to a personal zone hub (PZH) </label>
   </header>
   <fieldset class="boxBody">
+    <label> Set Device Friendly Name </label>
+    <input type="text" value="" id="friendlyName"> </input>
+    <label> Set Device Type </label>
+    <select value="deviceTypeList" id="deviceTypeList">
+      <option value="smartphone"> Phone </option>
+      <option value="tablet"> Tablet </option>
+      <option value="ivi"> Car </option>
+      <option value="tv"> TV </option>
+      <option value="homemediabox"> MediaCenter </option>
+      <option value="pc" selected="selected"> PC </option>
+      <option value="laptop"> Laptop </option>
+      <option value="iot"> IoT </option>
+      <option value="unknown"> Unknown </option>
+    </select>
+
     <label>Select your personal zone hub provider</label>
     <select value="pzh_list" id="pzh_list">
       <option value="pzh.webinos.org"> pzh.webinos.org</option>

--- a/web_root/js/index.js
+++ b/web_root/js/index.js
@@ -36,17 +36,26 @@ $ (document).ready (function () {
     }
 
     function connectedDetails () {
-        var pzhId, connectedDevices = webinos.session.getConnectedDevices(), text="Connected Devices:"; // all connected pzp
+        var connectedStatus, connectedDevices = webinos.session.getConnectedDevices(), text="Connected Devices:"; // all connected pzp
         $ ("#connectedDevices").html("");
+
         for (var i = 0; i < connectedDevices.length; i += 1) {
             if(!webinos.session.getPZHId()) {
-                text += "<li><a>" + webinos.session.getFriendlyName(connectedDevices[i].id) + (connectedDevices[i] === webinos.session.getPZPId()?" (Your Device)": "")+"</a></li>";
+                connectedStatus = (connectedDevices[i].isConnected === false) ? "#B0B0B0":"#FFFFFF";
+                text += "<p style='color:"+connectedStatus+";text-align:left'>" +
+                    webinos.session.getFriendlyName(connectedDevices[i].id) +
+                    (connectedDevices[i] === webinos.session.getPZPId()?" (Your Device)": "")+"</p>";
             } else {
-                console.log(connectedDevices[i]);
-                text += "<li><a>" + webinos.session.getFriendlyName(connectedDevices[i].id) + (connectedDevices[i].id === webinos.session.getPZHId()?" (Your Hub)": "")+"</a></li>";
+                connectedStatus = (connectedDevices[i].isConnected === false) ? "#B0B0B0":"#FFFFFF";
+                text += "<p style='color:"+connectedStatus+";text-align:left'>" +
+                    webinos.session.getFriendlyName(connectedDevices[i].id) +
+                    (connectedDevices[i].id === webinos.session.getPZHId()?" (Your Hub)": "")+"</p>";
                 if(connectedDevices[i].pzp){
                     for (var j=0; j < connectedDevices[i].pzp.length; j = j + 1) {
-                        text += "<ul><li><a>" + webinos.session.getFriendlyName(connectedDevices[i].pzp[j].id) + (connectedDevices[i].pzp[j].id === webinos.session.getPZPId()?" (Your Device)": "")+"</a></li></ul>";
+                        connectedStatus = (connectedDevices[i].pzp[j].isConnected === false) ? "#B0B0B0":"#FFFFFF";
+                        text += "<p style='color:"+connectedStatus+";text-align:center'>" +
+                            "<li>" + webinos.session.getFriendlyName(connectedDevices[i].pzp[j].id) +
+                            (connectedDevices[i].pzp[j].id === webinos.session.getPZPId()?" (Your Device)": "")+"</li></p>";
                     }
                 }
             }
@@ -87,7 +96,7 @@ $ (document).ready (function () {
     webinos.session.addListener ('info', printInfo);
 
     function error (msg) {
-        logMessage (msg.payload.message);
+        logMessage ("ERROR :"+ msg.payload.message);
     }
     webinos.session.addListener ('error', error);
 

--- a/wrt/webinos.session.js
+++ b/wrt/webinos.session.js
@@ -45,9 +45,9 @@ if (typeof _webinos === "undefined") {
     function updateConnected(message){
         if (message.pzhId) pzhId = message.pzhId;
         if (message.connectedDevices) connectedDevices = message.connectedDevices;
-        isConnected = !!(webinos.session.getConnectedPzh().indexOf(pzhId) !== -1);
         if (message.enrolled) enrolled = message.enrolled;
-        if (message.mode) mode = message.mode;
+        if (message.state) mode = message.state;
+        if (mode)  isConnected = (mode["Pzh"] === "connected" || mode["Pzp"] === "connected");
         if (message.hasOwnProperty("pzhWebAddress")) {
             webinos.session.setPzhWebAddress(message.pzhWebAddress);
         } 


### PR DESCRIPTION
 Setting device type and friendly name during enrollment
- Duplicate friendly name check at PZH during enrollment
- Device re-registration supported by changing device name
- userData details removed and userPref is read from config.json
- Webinos.session.getConnectedDevices() result updated to following format:[{"id":"", "friendlyName":"", photoUrl:"", isConnected:"", pzp:[{"id":"","friendlyName":"", deviceType:"", isConnected:""}]}]
