### PR TITLE
use correct paramter type for calling readJson

### DIFF
--- a/lib/pzp_receiveMessage.js
+++ b/lib/pzp_receiveMessage.js
@@ -138,7 +138,7 @@ var PzpReceiveMessage = function () {
     this.handleMsg=function (conn, buffer) {
         try {
             conn.pause (); // This pauses socket, cannot receive messages
-            PzpCommon.wUtil.webinosMsgProcessing.readJson(PzpObject, buffer, function (validMsgObj) {
+            PzpCommon.wUtil.webinosMsgProcessing.readJson(PzpObject.getSessionId(), buffer, function (validMsgObj) {
                 handleProcessedMessage(validMsgObj, "TLS", conn);
             });
         } catch (err) {


### PR DESCRIPTION
hopefully fixes "message confusion" and occasional exceptions

Jira-issue: WP-1258
