### PR TITLE
Changes to make PZP's code coherent with PZH's one

### DIFF
--- a/lib/pzp_serviceHandler.js
+++ b/lib/pzp_serviceHandler.js
@@ -91,8 +91,9 @@ var PzpServiceHandler = function () {
     }
 
     function loadModules() {
-        var nodeModulesPath = PzpCommon.path.join(__dirname, "../node_modules");
-        ownModules = PzpCommon.wUtil.webinosService.checkForWebinosModules(nodeModulesPath);
+        var nodeModulesPath = PzpCommon.path.join(__dirname, "../node_modules"),
+            userDataPath = PzpCommon.path.join(PzpObject.getMetaData("webinosRoot"), "userData");
+        ownModules = PzpCommon.wUtil.webinosService.checkForWebinosModules(nodeModulesPath, userDataPath);
         PzpCommon.wUtil.webinosService.loadServiceModules(ownModules, registry, rpcHandler,
           { http :
             { port : PzpObject.getWebinosPorts("pzp_webSocket")


### PR DESCRIPTION
Method checkForWebinosModule (webinos-utilities/lib/loadservice.js)
requires now userData folder path as second parameter

Jira issue: WP-1273
