### PR TITLE
add cli switch to enable verbose logging

### DIFF
--- a/lib/pzp_eventHandler.js
+++ b/lib/pzp_eventHandler.js
@@ -49,13 +49,13 @@ var PzpEventHandler = function() {
         return obj;
     }
     PzpObject.on("PZP_STARTED", function(msg){
-        logger.log("PZP_STARTED ");
+        logger.info("PZP_STARTED ");
     });
     PzpObject.on("PZH_CONNECTED", function(){
-        logger.log("PZH_CONNECTED");
+        logger.info("PZH_CONNECTED");
     });
     PzpObject.on("PZP_CONNECTED", function(){
-        logger.log("PZP_CONNECTED");
+        logger.info("PZP_CONNECTED");
     });
     PzpObject.on("EXCEPTION", function(err){
         var errDetails = getDetails();


### PR DESCRIPTION
this changes the previously verbose log messages to not be displayed by
default, they can be enabled by starting the pzp with "--debug". also
introduces info log messages to indicate successful start up.

Jira-issue: WP-1286
