### PR TITLE
Fix to for logging switch on browsers having localStorage set to null

### DIFF
--- a/wrt/webinos.session.js
+++ b/wrt/webinos.session.js
@@ -24,7 +24,7 @@ if (typeof exports.webinos.logging === "undefined") exports.webinos.logging = fu
     if(typeof enable === "boolean") {
         enable ? localStorage.setItem("verboseLoggingEnabled","true") : localStorage.removeItem("verboseLoggingEnabled");
     }
-    return (typeof localStorage != "undefined" && "true" === localStorage.getItem("verboseLoggingEnabled"));
+    return (typeof localStorage != "undefined" && localStorage && "true" === localStorage.getItem("verboseLoggingEnabled"));
 };
 
 if (typeof _webinos === "undefined") {


### PR DESCRIPTION
applies to e.g. Midori browser on RPi.

Jira-issue: WP-1286
