### PR TITLE
disable syncing of trustedList from PZP to PZH

### DIFF
--- a/lib/pzp_syncHandler.js
+++ b/lib/pzp_syncHandler.js
@@ -29,7 +29,7 @@ var PzpSync = function () {
         if (syncInstance) {
            //var policyFile = PzpCommon.fs.readFileSync(PzpCommon.path.join(PzpObject.getMetaData("webinosRoot"), "policies", "policy.xml"));
             list = {
-                trustedList : PzpObject.getTrustedList(),
+//                trustedList : PzpObject.getTrustedList(), // FIXME: before enrollment this is empty, therefor don't sync this to PZH
                 crl         : PzpObject.getCRL(),
                 externalCertificates: PzpObject.getExternalCertificateObj(),
                 signedCertificates  : PzpObject.getSignedCertificateObj(),


### PR DESCRIPTION
fixes bug where an empty trustedList is synced to PZH (right after
enrollment) overriding the info of the existing PZH there, which made it
impossible for other PZPs to join this PZH.
