### PR TITLE
Service cache sync fix

### DIFF
--- a/lib/pzp_syncHandler.js
+++ b/lib/pzp_syncHandler.js
@@ -101,13 +101,21 @@ var PzpSync = function () {
                     receivedMsg = receivedMsg.payload.message;
                 }
                 var list = prepareSyncList();
-                //list.connectedDevices={pzh:[],pzp:[]};
-//                var beforeApply = syncInstance.getObjectHash(list);
-//                var pzhCache = syncInstance.getObjectHash(receivedMsg);
+
+                if (receivedMsg.hasOwnProperty("serviceCache")){
+                  // This PZP owns the local list of services, so remove all local services from the remote list.
+                  receivedMsg["serviceCache"] = receivedMsg["serviceCache"].filter(function(svc) { return svc.serviceAddress !== PzpObject.getSessionId(); });
+
+                  // Remove all remote services from local list, this will ensure a complete sync of remote services,
+                  // including removal of obsolete services.
+                  if (list.hasOwnProperty("serviceCache")) {
+                    list["serviceCache"] = list["serviceCache"].filter(function(svc) { return svc.serviceAddress === PzpObject.getSessionId(); });
+                  }
+                }
+
                 var inNeedOfSync = 0;
                 var newList={};
                 var text = "";
-                if (receivedMsg !== {}) {
                     syncInstance.applyObjectContents(list, receivedMsg, PzpObject.getSessionId()); // After this step list is combined copy of local and remote copy
                     for (var key in list){
                         if (list.hasOwnProperty(key)){
@@ -143,11 +151,8 @@ var PzpSync = function () {
                     } else {
                         logger.log("Nothing synced with PZH");
                     }
-                }
                 // At this moment everything is synced, send sync to PZH. If there is anything that;s not synced could be synced with PZH
                 var checkChanges =  syncInstance.getObjectHash(list);
-                //PzpObject.prepMsg(receivedMsg.from, "syncHashAfterCompare", list_);
-                if (pzhCache !== {}){
                 for ( key in checkChanges ){
                     if (checkChanges.hasOwnProperty(key)){
                             if ((key === "serviceCache" || key ==="trustedList") && pzhCache[key] && checkChanges[key]!== pzhCache[key]) {
@@ -159,7 +164,6 @@ var PzpSync = function () {
                 if (inNeedOfSync === 1){
                    logger.log("PZP is in need of sync ");
                    PzpObject.prepMsg (id, "syncPzh", newList);
-                }
                 }
                 PzpObject.decideToKeepConnectionAliveOrClose(id);
                 pzhCache = {};


### PR DESCRIPTION
Change synchronisation code to explicitly handle service cache sync-ing such that local services are never sync'd from a remote source, and remote services always take precedence over those stored locally.
