### PR TITLE
Fixes reconnection problems in case of non-default PZH ports

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,8 +4,7 @@
         "provider_webServer": 443,
         "pzp_webSocket": 8080,
         "pzp_tlsServer": 8040,
-        "pzp_zeroConf": 4321,
-        "iot": 3000
+        "pzp_zeroConf": 4321
     },
     "friendlyName": "",
     "retryConnection": 3000,

--- a/lib/pzp_sessionHandling.js
+++ b/lib/pzp_sessionHandling.js
@@ -584,6 +584,7 @@ function Pzp(inputConfig) {
         config.metaData.pzhId            = from;
         config.metaData.serverName       = from && from.split ("@")[1];
         config.metaData.pzhWebAddress    = url.format(url.parse(payload.webAddress));
+        config.metaData.ports            = {provider: payload.serverPort, provider_webServer: url.parse(payload.webAddress).port};
         if((signedCert = config.cert.generateSignedCertificate(config.cert.internal.conn.csr))) {
             logger.log("connection signed certificate by PZP");
             config.cert.internal.conn.cert = signedCert;
@@ -711,6 +712,11 @@ function Pzp(inputConfig) {
                    virginPzpInitialization();
                 }else {
                     config.userPref.ports = require("../config.json").ports;
+                    //override default ports, if previously connected to a PZH with non-default ports
+                    if(config.metaData.ports && config.metaData.ports.provider && config.metaData.ports.provider_webServer){
+                       config.userPref.ports.provider = config.metaData.ports.provider;
+                       config.userPref.ports.provider_webServer = config.metaData.ports.provider_webServer;
+                    }
                 }
                 config.loadCertificates(config.cert);
                 if(config.metaData.pzhId) pzpState.enrolled = true;


### PR DESCRIPTION
In addition, removes unneeded "iot" port from the configuration.
This is already moved to the API implemenation.

Jira-issue: WP-1322
