### PR TITLE
Initialise WRT_HOME environment variable.

### DIFF
--- a/webinos_pzp.js
+++ b/webinos_pzp.js
@@ -166,6 +166,8 @@ function initializePzp (config) {
     logger = wutil.webinosLogging(__filename);
     logger.setConfig(config);
     PzpSession.setInputConfig(config);
+    // Set up path for widget storage.
+    process.env["WRT_HOME"] = path.join(wutil.webinosPath.webinosPath(),"wrt/widgetStore");
     startPzp();
 }
 


### PR DESCRIPTION
This variable is used by the widget manager to determine the widget storage location.

Setting the variable here de-couples the webinos-widget module from webinos-utitlities.
